### PR TITLE
Fix ally/base ability usage tracking

### DIFF
--- a/lib/realms/actions/ally_ability.rb
+++ b/lib/realms/actions/ally_ability.rb
@@ -7,7 +7,6 @@ module Realms
 
       def execute
         perform card.ally_ability
-        turn.activated_ally_ability << card
       end
     end
   end

--- a/lib/realms/actions/attack.rb
+++ b/lib/realms/actions/attack.rb
@@ -7,12 +7,12 @@ module Realms
 
       def execute
         case target
-        when Realms::Cards::Card
-          turn.combat -= target.defense
-          passive_player.deck.destroy(target)
         when Realms::Player
           turn.passive_player.authority -= turn.combat
           turn.combat = 0
+        else
+          turn.combat -= target.defense
+          passive_player.deck.destroy(target)
         end
       end
     end

--- a/lib/realms/actions/base_ability.rb
+++ b/lib/realms/actions/base_ability.rb
@@ -7,7 +7,6 @@ module Realms
 
       def execute
         perform card.primary_ability
-        turn.activated_base_ability << card
       end
     end
   end

--- a/lib/realms/cards/battlecruiser.rb
+++ b/lib/realms/cards/battlecruiser.rb
@@ -1,7 +1,7 @@
 module Realms
   module Cards
     class Battlecruiser < Card
-      faction :star_empire
+      faction Factions::STAR_ALLIANCE
       cost 6
       primary_ability Abilities::Combat[5]
       primary_ability Abilities::Draw[1]

--- a/lib/realms/cards/card.rb
+++ b/lib/realms/cards/card.rb
@@ -12,7 +12,14 @@ module Realms
           MACHINE_CULT = :machine_cult,
           STAR_ALLIANCE = :star_alliance,
         ]
+        UNALIGNED = :unaligned
+
+        def self.valid?(faction)
+          ALL.include?(faction) || faction == UNALIGNED
+        end
       end
+
+      class CardConfigurationError < StandardError; end
 
       class CardDefinition
         attr_accessor :type,
@@ -60,6 +67,7 @@ module Realms
       end
 
       def self.faction(faction)
+        raise CardConfigurationError, "invalid faction: #{faction}" unless Factions.valid?(faction)
         definition.factions << faction
       end
 
@@ -144,11 +152,6 @@ module Realms
 
       def outpost?
         type == :outpost
-      end
-
-      def ally_ability_activated?
-        return false if factions.reject { |f| f == :unaligned }.empty?
-        (owner.deck.in_play - [self]).any? { |card| (card.ally_factions & factions).present? }
       end
 
       def inspect

--- a/lib/realms/cards/card.rb
+++ b/lib/realms/cards/card.rb
@@ -102,7 +102,7 @@ module Realms
       end
 
       def zone
-        if_none = ->() { raise "card lost: #{card}" }
+        if_none = ->() { raise "card lost: #{self}" }
         owner.zones.find(if_none) { |z| z.include?(self) }
       end
 

--- a/lib/realms/cards/corvette.rb
+++ b/lib/realms/cards/corvette.rb
@@ -1,7 +1,7 @@
 module Realms
   module Cards
     class Corvette < Card
-      faction :star_empire
+      faction Factions::STAR_ALLIANCE
       cost 2
       primary_ability Abilities::Combat[1]
       primary_ability Abilities::Draw[1]

--- a/lib/realms/cards/dreadnaught.rb
+++ b/lib/realms/cards/dreadnaught.rb
@@ -1,7 +1,7 @@
 module Realms
   module Cards
     class Dreadnaught < Card
-      faction :star_empire
+      faction Factions::STAR_ALLIANCE
       cost 7
       primary_ability Abilities::Combat[7]
       primary_ability Abilities::Draw[1]

--- a/lib/realms/cards/imperial_fighter.rb
+++ b/lib/realms/cards/imperial_fighter.rb
@@ -1,7 +1,7 @@
 module Realms
   module Cards
     class ImperialFighter < Card
-      faction :star_empire
+      faction Factions::STAR_ALLIANCE
       cost 1
       primary_ability Abilities::Combat[2]
       primary_ability Abilities::Discard[1]

--- a/lib/realms/cards/imperial_frigate.rb
+++ b/lib/realms/cards/imperial_frigate.rb
@@ -1,7 +1,7 @@
 module Realms
   module Cards
     class ImperialFrigate < Card
-      faction :star_empire
+      faction Factions::STAR_ALLIANCE
       cost 3
       primary_ability Abilities::Combat[4]
       primary_ability Abilities::Discard[1]

--- a/lib/realms/cards/recycling_station.rb
+++ b/lib/realms/cards/recycling_station.rb
@@ -3,7 +3,7 @@ module Realms
     class RecyclingStation < Card
       type :outpost
       defense 4
-      faction :star_empire
+      faction Factions::STAR_ALLIANCE
       cost 4
       primary_ability Abilities::Choose[
         Abilities::Trade[1],

--- a/lib/realms/cards/royal_redoubt.rb
+++ b/lib/realms/cards/royal_redoubt.rb
@@ -3,7 +3,7 @@ module Realms
     class RoyalRedoubt < Card
       type :outpost
       defense 6
-      faction :star_empire
+      faction Factions::STAR_ALLIANCE
       cost 6
       primary_ability Abilities::Combat[3]
       ally_ability Abilities::Discard[1]

--- a/lib/realms/cards/space_station.rb
+++ b/lib/realms/cards/space_station.rb
@@ -3,7 +3,7 @@ module Realms
     class SpaceStation < Card
       type :outpost
       defense 4
-      faction :star_empire
+      faction Factions::STAR_ALLIANCE
       cost 4
       primary_ability Abilities::Combat[2]
       ally_ability Abilities::Combat[2]

--- a/lib/realms/cards/survey_ship.rb
+++ b/lib/realms/cards/survey_ship.rb
@@ -1,7 +1,7 @@
 module Realms
   module Cards
     class SurveyShip < Card
-      faction :star_empire
+      faction Factions::STAR_ALLIANCE
       cost 3
       primary_ability Abilities::Trade[1]
       primary_ability Abilities::Draw[1]

--- a/lib/realms/cards/war_world.rb
+++ b/lib/realms/cards/war_world.rb
@@ -3,7 +3,7 @@ module Realms
     class WarWorld < Card
       type :outpost
       defense 4
-      faction :star_empire
+      faction Factions::STAR_ALLIANCE
       cost 5
       primary_ability Abilities::Combat[3]
       ally_ability Abilities::Combat[4]

--- a/lib/realms/turn.rb
+++ b/lib/realms/turn.rb
@@ -16,9 +16,7 @@ module Realms
                 :passive_player,
                 :trade_deck
     attr_accessor :trade,
-                  :combat,
-                  :activated_ally_ability,
-                  :activated_base_ability
+                  :combat
 
     def initialize(active_player, passive_player, trade_deck)
       @id = self.class.next_id
@@ -27,8 +25,6 @@ module Realms
       @trade_deck = trade_deck
       @trade = 0
       @combat = 0
-      @activated_ally_ability = []
-      @activated_base_ability = []
     end
 
     def execute

--- a/lib/realms/zones/in_play.rb
+++ b/lib/realms/zones/in_play.rb
@@ -1,11 +1,28 @@
 module Realms
   module Zones
     class InPlay < Zone
+      attr_accessor :ally_abilities,
+                    :base_abilities
+
+      def initialize(*args)
+        super
+        @ally_abilities = []
+        @base_abilities = []
+      end
+
+      # TODO: The timing is going to be a little tricky here.
+      #
+      # 1) Keep track of used ally/base abilities (rm from turn state)
+      # 2) Keep track of when ally abilities are eligible for use
+      # 3) Hook for automatic execution of ally/passive abilities
+      def on_card_added(zt)
+        # self.ally_abilities << zt.card if card.ally_ability?
+        # self.base_abilities << zt.card if card.base?
+      end
+
       def actions
         return attack_actions if owner == active_turn.passive_player
-        base_actions +
-          ally_actions +
-          scrap_actions
+        base_actions + ally_actions + scrap_actions
       end
 
       private

--- a/lib/realms/zones/in_play.rb
+++ b/lib/realms/zones/in_play.rb
@@ -23,8 +23,8 @@ module Realms
         super.tap { self.ally_activated = false }
       end
 
-      def base_ability
-        super.tap { self.base_actviated = false }
+      def primary_ability
+        super.tap { self.base_activated = false }
       end
 
       private
@@ -67,7 +67,7 @@ module Realms
         cards.each_with_object([]) do |card, actions|
           next unless card.ally_activated?
 
-          if (cards - [card]).any? { |cip| (cip.factions & card.factions).present? }
+          if (cards - [card]).any? { |cip| (cip.ally_factions & card.ally_factions).present? }
             actions << Actions::AllyAbility.new(active_turn, card)
           end
         end

--- a/lib/realms/zones/in_play.rb
+++ b/lib/realms/zones/in_play.rb
@@ -48,6 +48,10 @@ module Realms
         cards.include?(card) || cards.map(&:card).include?(card)
       end
 
+      def remove(card)
+        super.card
+      end
+
       def actions
         return attack_actions if owner == active_turn.passive_player
         base_actions + ally_actions + scrap_actions

--- a/realms.gemspec
+++ b/realms.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "byebug"
-  spec.add_dependency "activesupport", "5.0.2"
+  spec.add_dependency "activesupport", "~> 5.1"
   spec.add_dependency "wisper", "2.0.0"
   spec.add_dependency "equalizer"
 end

--- a/spec/actions/ally_ability_spec.rb
+++ b/spec/actions/ally_ability_spec.rb
@@ -14,17 +14,17 @@ RSpec.describe Realms::Actions::AllyAbility do
     end
 
     it "triggers both cards" do
-      game.play(:blob_fighter_0)
-      expect(game.current_choice.options).to_not have_key(:blob_fighter_0)
+      game.play(card1)
+      expect(game.current_choice.options).to_not have_key(:"ally_ability.blob_fighter_0")
 
-      game.play(:battle_pod_0)
+      game.play(card2)
       game.decide(game.trade_deck.trade_row.sample.key)
 
-      expect { game.ally_ability(:blob_fighter_0) }.to change { game.active_turn.active_player.deck.hand.length }.by(1)
-      expect { game.ally_ability(:battle_pod_0) }.to change { game.active_turn.combat }.by(2)
+      expect { game.ally_ability(card1) }.to change { game.active_turn.active_player.deck.hand.length }.by(1)
+      expect { game.ally_ability(card2) }.to change { game.active_turn.combat }.by(2)
 
-      expect(game.current_choice.options).to_not have_key(:blob_fighter_0)
-      expect(game.current_choice.options).to_not have_key(:battle_pod_0)
+      expect(game.current_choice.options).to_not have_key(:"ally_ability.blob_fighter_0")
+      expect(game.current_choice.options).to_not have_key(:"ally_ability.battle_pod_0")
     end
   end
 
@@ -39,14 +39,14 @@ RSpec.describe Realms::Actions::AllyAbility do
     end
 
     it "triggers both cards once" do
-      game.play(:blob_fighter_0)
-      game.play(:blob_fighter_1)
+      game.play(card1)
+      game.play(card2)
 
-      expect { game.ally_ability(:blob_fighter_0) }.to change { game.active_turn.active_player.deck.hand.length }.by(1)
-      expect { game.ally_ability(:blob_fighter_1) }.to change { game.active_turn.active_player.deck.hand.length }.by(1)
+      expect { game.ally_ability(card1) }.to change { game.active_turn.active_player.deck.hand.length }.by(1)
+      expect { game.ally_ability(card2) }.to change { game.active_turn.active_player.deck.hand.length }.by(1)
 
-      expect(game.current_choice.options).to_not have_key(:blob_fighter_0)
-      expect(game.current_choice.options).to_not have_key(:blob_fighter_1)
+      expect(game.current_choice.options).to_not have_key(:"ally_ability.blob_fighter_0")
+      expect(game.current_choice.options).to_not have_key(:"ally_ability.blob_fighter_1")
     end
   end
 end

--- a/spec/actions/attack_spec.rb
+++ b/spec/actions/attack_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe Realms::Actions::Attack do
 
       it "can attack the base" do
         game.attack(base)
-        expect(game.p2.deck.discard_pile).to include(base)
+        expect(base.zone).to eq(game.p2.discard_pile)
+        expect(base.class).to eq(Realms::Cards::BlobWheel)
         expect(game.p2.authority).to eq(50)
         game.attack(game.p2)
         expect(game.p2.authority).to eq(49)

--- a/spec/actions/base_ability_spec.rb
+++ b/spec/actions/base_ability_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Realms::Actions::BaseAbility do
   before do
     game.p1.deck.in_play << card
     game.start
-    game.base_ability(:blob_wheel_0)
+    game.base_ability(card)
   end
 
   it do
     expect(game.active_turn.combat).to eq(1)
-    expect { game.base_ability(:blob_wheel_0) }.to raise_error(Realms::Choice::InvalidOption)
+    expect { game.base_ability(card) }.to raise_error(Realms::Choice::InvalidOption)
   end
 end

--- a/spec/cards/battlecruiser_spec.rb
+++ b/spec/cards/battlecruiser_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Realms::Cards::Battlecruiser do
   let(:game) { Realms::Game.new }
   let(:card) { described_class.new(game.p1) }
 
-  include_examples "factions", :star_empire
+  include_examples "factions", Realms::Cards::Card::Factions::STAR_ALLIANCE
   include_examples "cost", 6
 
   describe "#primary_ability" do

--- a/spec/cards/brain_world_spec.rb
+++ b/spec/cards/brain_world_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Realms::Cards::BrainWorld do
       before do
         game.p1.deck.hand.concat(Array.wrap(hand))
         game.p1.deck.discard_pile.concat(Array.wrap(discard_pile))
-        game.p1.deck.in_play.concat(Array.wrap(discard_pile))
+        game.p1.deck.in_play.concat(Array.wrap(in_play))
         game.start
         game.play(card)
         game.base_ability(card)

--- a/spec/cards/corvette_spec.rb
+++ b/spec/cards/corvette_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Realms::Cards::Corvette do
   let(:game) { Realms::Game.new }
   let(:card) { described_class.new(game.p1) }
 
-  include_examples "factions", :star_empire
+  include_examples "factions", Realms::Cards::Card::Factions::STAR_ALLIANCE
   include_examples "cost", 2
 
   describe "#primary_ability" do

--- a/spec/cards/cutter_spec.rb
+++ b/spec/cards/cutter_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Realms::Cards::Cutter do
       game.p1.deck.hand << ally_card
       game.start
       game.play(card)
+      game.play(ally_card)
     end
 
     it { expect { game.ally_ability(card) }.to change { game.active_turn.combat }.by(4) }

--- a/spec/cards/dreadnaught_spec.rb
+++ b/spec/cards/dreadnaught_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Realms::Cards::Dreadnaught do
   let(:game) { Realms::Game.new }
   let(:card) { described_class.new(game.p1) }
 
-  include_examples "factions", :star_empire
+  include_examples "factions", Realms::Cards::Card::Factions::STAR_ALLIANCE
   include_examples "cost", 7
 
   describe "#primary_ability" do

--- a/spec/cards/imperial_fighter_spec.rb
+++ b/spec/cards/imperial_fighter_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Realms::Cards::ImperialFighter do
   let(:game) { Realms::Game.new }
   let(:card) { described_class.new(game.p1) }
 
-  include_examples "factions", :star_empire
+  include_examples "factions", Realms::Cards::Card::Factions::STAR_ALLIANCE
   include_examples "cost", 1
 
   describe "#primary_ability" do

--- a/spec/cards/imperial_frigate_spec.rb
+++ b/spec/cards/imperial_frigate_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Realms::Cards::ImperialFrigate do
   let(:game) { Realms::Game.new }
   let(:card) { described_class.new(game.p1) }
 
-  include_examples "factions", :star_empire
+  include_examples "factions", Realms::Cards::Card::Factions::STAR_ALLIANCE
   include_examples "cost", 3
 
   describe "#primary_ability" do

--- a/spec/cards/recycling_station_spec.rb
+++ b/spec/cards/recycling_station_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Realms::Cards::RecyclingStation do
 
   include_examples "type", :outpost
   include_examples "defense", 4
-  include_examples "factions", :star_empire
+  include_examples "factions", Realms::Cards::Card::Factions::STAR_ALLIANCE
   include_examples "cost", 4
 
   describe "#primary_ability" do

--- a/spec/cards/royal_redoubt_spec.rb
+++ b/spec/cards/royal_redoubt_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Realms::Cards::RoyalRedoubt do
 
   include_examples "type", :outpost
   include_examples "defense", 6
-  include_examples "factions", :star_empire
+  include_examples "factions", Realms::Cards::Card::Factions::STAR_ALLIANCE
   include_examples "cost", 6
 
   describe "#primary_ability" do

--- a/spec/cards/space_station_spec.rb
+++ b/spec/cards/space_station_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Realms::Cards::SpaceStation do
 
   include_examples "type", :outpost
   include_examples "defense", 4
-  include_examples "factions", :star_empire
+  include_examples "factions", Realms::Cards::Card::Factions::STAR_ALLIANCE
   include_examples "cost", 4
 
   describe "#primary_ability" do

--- a/spec/cards/survey_ship_spec.rb
+++ b/spec/cards/survey_ship_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Realms::Cards::SurveyShip do
   let(:game) { Realms::Game.new }
   let(:card) { described_class.new(game.p1) }
 
-  include_examples "factions", :star_empire
+  include_examples "factions", Realms::Cards::Card::Factions::STAR_ALLIANCE
   include_examples "cost", 3
 
   describe "#primary_ability" do

--- a/spec/cards/war_world_spec.rb
+++ b/spec/cards/war_world_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Realms::Cards::WarWorld do
 
   include_examples "type", :outpost
   include_examples "defense", 4
-  include_examples "factions", :star_empire
+  include_examples "factions", Realms::Cards::Card::Factions::STAR_ALLIANCE
   include_examples "cost", 5
 
   describe "#primary_ability" do

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -35,8 +35,8 @@ shared_examples "destroy_target_base" do
     end
 
     it "must choose the outpost card first" do
-      expect(game.current_choice.options).to have_value(outpost_card)
-      expect(game.current_choice.options).to_not have_value(base_card)
+      expect(game.current_choice.options).to have_key(outpost_card.key)
+      expect(game.current_choice.options).to_not have_key(base_card.key)
       game.decide(outpost_card.key)
       expect(game.p1.deck.discard_pile).to include(outpost_card)
     end


### PR DESCRIPTION
When testing in the web ui, I noticed that ally abilities were triggering themselves, and not correctly limiting use to once per play.

This was due to a typo in the test that was erroneously left behind after changing the decision key scheme.