### PR TITLE
impl fleet hq and first stab at “static” abilities

### DIFF
--- a/lib/realms/abilities/ability.rb
+++ b/lib/realms/abilities/ability.rb
@@ -11,6 +11,10 @@ module Realms
         @optional = optional
       end
 
+      def self.static?
+        false
+      end
+
       class_attribute :arg, instance_predicate: false, instance_writer: false
 
       def self.[](arg)

--- a/lib/realms/actions/acquire_card.rb
+++ b/lib/realms/actions/acquire_card.rb
@@ -1,10 +1,6 @@
 module Realms
   module Actions
     class AcquireCard < Action
-      include Wisper::Publisher
-
-      attr_accessor :zone
-
       def self.key
         :acquire
       end

--- a/lib/realms/actions/play_card.rb
+++ b/lib/realms/actions/play_card.rb
@@ -7,7 +7,8 @@ module Realms
 
       def execute
         active_player.deck.play(card)
-        perform card.primary_ability unless card.base?
+        perform card.primary_ability if card.ship? || card.static?
+        turn.send(:broadcast, :card_played, card)
       end
     end
   end

--- a/lib/realms/cards/card.rb
+++ b/lib/realms/cards/card.rb
@@ -54,6 +54,14 @@ module Realms
           return scrap_abilities.first unless scrap_abilities.many?
           Abilities::Multi[scrap_abilities]
         end
+
+        def initialize_copy(source)
+          super
+          @factions = source.factions.dup
+          @primary_abilities = source.primary_abilities.dup
+          @ally_abilities = source.ally_abilities.dup
+          @scrap_abilities = source.scrap_abilities.dup
+        end
       end
 
       include Equalizer.new(:key)
@@ -140,6 +148,10 @@ module Realms
 
       def blob?
         factions.include?(:blob)
+      end
+
+      def static?
+        definition.primary_abilities.any?(&:static?)
       end
 
       def ship?

--- a/lib/realms/cards/fleet_h_q.rb
+++ b/lib/realms/cards/fleet_h_q.rb
@@ -1,0 +1,37 @@
+module Realms
+  module Abilities
+    class AllShipsGetCombat < Ability
+      def self.key
+        :all_ships_combat
+      end
+
+      def self.static?
+        true
+      end
+
+      def execute
+        card.zone.on(:on_card_added) do |zt|
+          played_card = zt.card
+
+          turn.on(:turn_end) { played_card.definition = played_card.class.definition }
+
+          if played_card.ship?
+            played_card.definition = played_card.definition.dup.tap do |defn|
+              defn.primary_abilities << Abilities::Combat[arg]
+            end
+          end
+        end
+      end
+    end
+  end
+
+  module Cards
+    class FleetHQ < Card
+      faction Factions::STAR_ALLIANCE
+      type :base
+      defense 8
+      cost 8
+      primary_ability Abilities::AllShipsGetCombat[1]
+    end
+  end
+end

--- a/spec/cards/fleet_h_q_spec.rb
+++ b/spec/cards/fleet_h_q_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+
+RSpec.describe Realms::Cards::FleetHQ do
+  let(:game) { Realms::Game.new }
+  let(:card) { described_class.new(game.p1) }
+
+  include_examples "type", :base
+  include_examples "defense", 8
+  include_examples "factions", Realms::Cards::Card::Factions::STAR_ALLIANCE
+  include_examples "cost", 8
+
+  # NOTE: http://www.starrealms.com/faq/
+  #
+  describe "#primary_ability" do
+    let(:viper_0) { Realms::Cards::Viper.new(game.p1, index: 10) }
+    let(:viper_1) { Realms::Cards::Viper.new(game.p1, index: 11) }
+    let(:scout_0) { Realms::Cards::Scout.new(game.p1, index: 10) }
+    let(:scout_1) { Realms::Cards::Scout.new(game.p1, index: 11) }
+    let(:scout_2) { Realms::Cards::Scout.new(game.p1, index: 12) }
+
+    let(:hand) do
+      Realms::Zones::Hand.new(game.p1, [
+        viper_0,
+        viper_1,
+        scout_0,
+        scout_1,
+        scout_2,
+      ])
+    end
+
+    before do
+      game.p1.deck.hand = hand
+      game.p1.hand << card
+      game.start
+    end
+
+    it "adds one combat to all ships played after fleet hq" do
+      expect { game.play(viper_0) }.to change { game.active_turn.combat }.by(1)
+      expect { game.play(scout_0) }.to change { game.active_turn.combat }.by(0)
+      game.play(card)
+      expect { game.play(scout_1) }.to change { game.active_turn.combat }.by(1)
+      expect { game.play(scout_2) }.to change { game.active_turn.combat }.by(1)
+      expect { game.play(viper_1) }.to change { game.active_turn.combat }.by(2)
+      expect(game.active_turn.combat).to eq(5)
+      game.end_turn
+    end
+  end
+end


### PR DESCRIPTION
Been thinking about this one for a bit:

Goals:

1. Augment the played cards primary ability to include a combat[1] ability. If done at the right time, I shouldn't need to manually execute it since it will get turned into a multi ability upon instantiation from the card definition.
2. Add some support for future static abilities
3. Think about possible future extension point for "source" of augmentation. For example, if a card that came into play wanted to display a "+1 Combat from FleetHQ".