### PR TITLE
swap out wisper for brainguy for observer impl

### DIFF
--- a/lib/realms.rb
+++ b/lib/realms.rb
@@ -1,6 +1,6 @@
 require "realms/version"
 require "active_support/all"
-require "wisper"
+require "brainguy"
 require "realms/game"
 
 module Realms

--- a/lib/realms/abilities/ability.rb
+++ b/lib/realms/abilities/ability.rb
@@ -1,6 +1,8 @@
 module Realms
   module Abilities
     class Ability < Yielder
+      include Brainguy::Observer
+
       attr_reader :card, :turn, :optional
 
       delegate :active_player, :trade_deck, to: :turn

--- a/lib/realms/abilities/copy_ship.rb
+++ b/lib/realms/abilities/copy_ship.rb
@@ -7,7 +7,6 @@ module Realms
 
       def execute
         choose(Choice.new(ships)) do |ship|
-          turn.on(:turn_end) { card.definition = card.class.definition }
           card.definition = ship.definition.clone.tap do |definition|
             card.factions.each { |faction| definition.factions << faction }
           end

--- a/lib/realms/abilities/top_deck_next_ship.rb
+++ b/lib/realms/abilities/top_deck_next_ship.rb
@@ -6,12 +6,15 @@ module Realms
       end
 
       def execute
-        trade_deck.trade_row.on(:before_card_removed) do |zt|
-          if zt.card.ship? && @once.nil?
-            zt.destination = active_player.deck.draw_pile
-            zt.destination_position = 0
-            @once = true # NOTE: hack since you can't unsubscribe?!
-          end
+        trade_deck.trade_row.events.attach(self)
+      end
+
+      def on_removing_card(event)
+        zt = event.args.first
+        if zt.card.ship?
+          zt.destination = active_player.deck.draw_pile
+          zt.destination_position = 0
+          trade_deck.trade_row.events.detach(self)
         end
       end
     end

--- a/lib/realms/actions/play_card.rb
+++ b/lib/realms/actions/play_card.rb
@@ -8,7 +8,6 @@ module Realms
       def execute
         active_player.deck.play(card)
         perform card.primary_ability if card.ship? || card.static?
-        turn.send(:broadcast, :card_played, card)
       end
     end
   end

--- a/lib/realms/cards/fleet_h_q.rb
+++ b/lib/realms/cards/fleet_h_q.rb
@@ -10,17 +10,20 @@ module Realms
       end
 
       def execute
-        card.zone.on(:on_card_added) do |zt|
-          played_card = zt.card
+        card.owner.in_play.events.attach(self)
+      end
 
-          turn.on(:turn_end) { played_card.definition = played_card.class.definition }
-
-          if played_card.ship?
-            played_card.definition = played_card.definition.dup.tap do |defn|
-              defn.primary_abilities << Abilities::Combat[arg]
-            end
+      def on_card_added(event)
+        played_card = event.args.first.card
+        if played_card.ship?
+          played_card.definition = played_card.definition.dup.tap do |defn|
+            defn.primary_abilities << Abilities::Combat[arg]
           end
         end
+      end
+
+      def on_card_removed(event)
+        card.owner.in_play.events.detach(self)
       end
     end
   end

--- a/lib/realms/deck.rb
+++ b/lib/realms/deck.rb
@@ -15,7 +15,7 @@ module Realms
       @player = player
       @zones = [
         @draw_pile = Zones::Zone.new(player, starting_deck),
-        @discard_pile = Zones::Zone.new(player),
+        @discard_pile = Zones::DiscardPile.new(player),
         @hand = Zones::Hand.new(player),
         @in_play = Zones::InPlay.new(player),
       ]

--- a/lib/realms/turn.rb
+++ b/lib/realms/turn.rb
@@ -3,8 +3,6 @@ require "realms/phases"
 
 module Realms
   class Turn < Yielder
-    include Wisper::Publisher
-
     @id = 0
 
     def self.next_id
@@ -32,7 +30,6 @@ module Realms
       perform Phases::Main.new(self)
       perform Phases::Discard.new(self)
       perform Phases::Draw.new(self)
-      broadcast(:turn_end)
     end
   end
 end

--- a/lib/realms/zones.rb
+++ b/lib/realms/zones.rb
@@ -3,6 +3,7 @@ require "realms/zones/trade_row"
 require "realms/zones/explorers"
 require "realms/zones/hand"
 require "realms/zones/in_play"
+require "realms/zones/discard_pile"
 
 module Realms
   module Zones

--- a/lib/realms/zones/discard_pile.rb
+++ b/lib/realms/zones/discard_pile.rb
@@ -1,0 +1,10 @@
+module Realms
+  module Zones
+    class DiscardPile < Zone
+      def on_card_added(event)
+        zt = event.args.first
+        zt.card.definition = zt.card.class.definition
+      end
+    end
+  end
+end

--- a/lib/realms/zones/trade_row.rb
+++ b/lib/realms/zones/trade_row.rb
@@ -1,8 +1,8 @@
 module Realms
   module Zones
     class TradeRow < Zone
-      def on_card_removed(zt)
-        owner.draw_pile.transfer!(to: self, pos: zt.source_position)
+      def on_card_removed(event)
+        owner.draw_pile.transfer!(to: self, pos: event.args.first.source_position)
       end
 
       def actions

--- a/lib/realms/zones/transfer.rb
+++ b/lib/realms/zones/transfer.rb
@@ -18,7 +18,8 @@ module Realms
       def transfer!
         raise InvalidTarget, card.key if !source.include?(card) || destination.include?(card)
         card.owner = destination.owner
-        destination.insert(destination_position, source.remove(card))
+        self.card = source.remove(card)
+        destination.insert(destination_position, card)
       end
     end
   end

--- a/realms.gemspec
+++ b/realms.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "byebug"
   spec.add_dependency "activesupport", "~> 5.1"
-  spec.add_dependency "wisper", "2.0.0"
+  spec.add_dependency "brainguy"
   spec.add_dependency "equalizer"
 end

--- a/spec/cards/fleet_h_q_spec.rb
+++ b/spec/cards/fleet_h_q_spec.rb
@@ -55,6 +55,27 @@ RSpec.describe Realms::Cards::FleetHQ do
       expect(scout_1.definition.primary_abilities.map(&:key)).to eq([:trade])
       expect(scout_2.definition.primary_abilities.map(&:key)).to eq([:trade])
       expect(viper_1.definition.primary_abilities.map(&:key)).to eq([:combat])
+
+      # kill fleethq
+      #
+      dreadnaught = Realms::Cards::Dreadnaught.new(game.p2)
+      some_card = game.p2.hand.sample
+      game.p2.hand << dreadnaught
+      game.play(some_card)
+      expect {
+        game.play(dreadnaught)
+        game.scrap_ability(dreadnaught)
+      }.to change { game.active_turn.combat }.by(12)
+      game.attack(card)
+      expect(card.zone).to eq(game.p1.discard_pile)
+
+      game.end_turn
+
+      # Check to see that fleet hq isn't still active - this kinda sucks
+      #
+      some_card = game.p1.hand.sample
+      game.play(some_card)
+      expect(some_card.definition.primary_abilities.length).to eq(1)
     end
   end
 end


### PR DESCRIPTION
It seems like wisper was designed for web applications and short lived objects. This was made evident in the lack of an unsubscribe method for local registrations. The realms program has long lived objects that move into and out of various zones - subscribing and unsubscribing as necessary. 

Having gotten used to wisper, I followed up on the project repo. There's a closed issue that alludes to adding the feature in version 2.0. I left a comment, we'll see what the author thinks.

In the meantime, I looked around a bit and landed on brainguy. It seems pretty good. I find passing event arguments to be kind of awkward, but I imagine it was done that way to be minimal. I don't do that much event passing, so I'll deal for a bit - maybe I'm missing something in the docs.

Who knows maybe I'll be rolling my own.