### PR TITLE
don't include stealth needle in copy ship options

### DIFF
--- a/lib/realms/abilities/copy_ship.rb
+++ b/lib/realms/abilities/copy_ship.rb
@@ -15,7 +15,7 @@ module Realms
       end
 
       def ships
-        active_player.deck.in_play.select(&:ship?)
+        active_player.in_play.select(&:ship?).index_by(&:key).except(card.key).values
       end
     end
   end

--- a/spec/cards/stealth_needle_spec.rb
+++ b/spec/cards/stealth_needle_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Realms::Cards::StealthNeedle do
              change { game.p1.authority }.by(4)
 
         game.play(card)
+        expect(game.current_choice.options.keys).to_not include(card.key)
 
         expect {
           game.decide(another_ship.key)


### PR DESCRIPTION
Fixes #14 