### PR TITLE
observe zone to maintain in play card state

### DIFF
--- a/lib/realms/cards/blob_world.rb
+++ b/lib/realms/cards/blob_world.rb
@@ -6,7 +6,7 @@ module Realms
       end
 
       def execute
-        num = active_player.in_play.select { |c| c.played_this_turn? && c.blob? }.length
+        num = active_player.in_play.cards_in_play.count { |c| c.played_this_turn? && c.blob? }
         turn.active_player.draw(num)
       end
     end

--- a/lib/realms/phases/discard.rb
+++ b/lib/realms/phases/discard.rb
@@ -5,7 +5,7 @@ module Realms
         turn.trade = 0
         turn.combat = 0
         deck.in_play.select(&:ship?).each { |ship| deck.destroy(ship) }
-        deck.in_play.select(&:base?).each { |base| base.reset! }
+        deck.in_play.cards_in_play.select(&:base?).each { |base| base.reset! }
         deck.discard_hand
       end
 

--- a/lib/realms/zones.rb
+++ b/lib/realms/zones.rb
@@ -1,4 +1,5 @@
 require "realms/zones/zone"
+require "realms/zones/null"
 require "realms/zones/trade_row"
 require "realms/zones/explorers"
 require "realms/zones/hand"

--- a/lib/realms/zones/null.rb
+++ b/lib/realms/zones/null.rb
@@ -1,0 +1,20 @@
+module Realms
+  module Zones
+    class Null < Zone
+      def cards
+        []
+      end
+
+      def include?(card)
+        true
+      end
+
+      def index(card)
+      end
+
+      def remove(card)
+        card
+      end
+    end
+  end
+end

--- a/lib/realms/zones/zone.rb
+++ b/lib/realms/zones/zone.rb
@@ -17,7 +17,7 @@ module Realms
         to: :owner
 
       def <<(card)
-        self.cards << card
+        null_zone.transfer!(card: card, to: self)
       end
 
       def each(&block)
@@ -45,6 +45,12 @@ module Realms
 
       def remove(card)
         cards.delete_at(cards.index(card) || cards.length)
+      end
+
+      private
+
+      def null_zone
+        @null_zone ||= Null.new(owner)
       end
     end
   end


### PR DESCRIPTION
Rather than wrapping the zone's cards, instead use the transfer events to maintain a `cards_in_play` structure that provides easy access to zone state for a given card.

I wonder if this could be expanded upon for all zones.

Also implementing the convenience  method `<<` using the null object  pattern.

Should close out #16 