### PR TITLE
Introduce automatic ally abilities

### DIFF
--- a/lib/realms/abilities/ability.rb
+++ b/lib/realms/abilities/ability.rb
@@ -13,6 +13,10 @@ module Realms
         @optional = optional
       end
 
+      def self.auto?
+        false
+      end
+
       def self.static?
         false
       end

--- a/lib/realms/abilities/authority.rb
+++ b/lib/realms/abilities/authority.rb
@@ -5,6 +5,10 @@ module Realms
         :authority
       end
 
+      def self.auto?
+        true
+      end
+
       def execute
         turn.active_player.authority += arg
       end

--- a/lib/realms/abilities/combat.rb
+++ b/lib/realms/abilities/combat.rb
@@ -5,6 +5,10 @@ module Realms
         :combat
       end
 
+      def self.auto?
+        true
+      end
+
       def execute
         turn.combat += arg
       end

--- a/lib/realms/abilities/trade.rb
+++ b/lib/realms/abilities/trade.rb
@@ -5,6 +5,10 @@ module Realms
         :trade
       end
 
+      def self.auto?
+        true
+      end
+
       def execute
         turn.trade += arg
       end

--- a/lib/realms/actions/action.rb
+++ b/lib/realms/actions/action.rb
@@ -21,6 +21,10 @@ module Realms
         "#{self.class.key}.#{target.key}"
       end
 
+      def auto?
+        false
+      end
+
       def execute
       end
     end

--- a/lib/realms/actions/ally_ability.rb
+++ b/lib/realms/actions/ally_ability.rb
@@ -5,6 +5,10 @@ module Realms
         :ally_ability
       end
 
+      def auto?
+        card.automatic_ally_ability?
+      end
+
       def execute
         perform card.ally_ability
       end

--- a/lib/realms/actions/play_card.rb
+++ b/lib/realms/actions/play_card.rb
@@ -8,6 +8,9 @@ module Realms
       def execute
         active_player.deck.play(card)
         perform card.primary_ability if card.ship? || card.static?
+        active_player.in_play.automatic_actions.each do |action|
+          perform action
+        end
       end
     end
   end

--- a/lib/realms/cards/card.rb
+++ b/lib/realms/cards/card.rb
@@ -146,6 +146,10 @@ module Realms
         definition.ally_abilities.any?
       end
 
+      def automatic_ally_ability?
+        definition.ally_abilities.any?(&:auto?)
+      end
+
       def blob?
         factions.include?(:blob)
       end

--- a/lib/realms/zones/in_play.rb
+++ b/lib/realms/zones/in_play.rb
@@ -23,6 +23,10 @@ module Realms
         base_actions + ally_actions + scrap_actions
       end
 
+      def automatic_actions
+        actions.select(&:auto?)
+      end
+
       def cards_in_play
         in_play.values
       end

--- a/lib/realms/zones/zone.rb
+++ b/lib/realms/zones/zone.rb
@@ -47,6 +47,10 @@ module Realms
         cards.delete_at(cards.index(card) || cards.length)
       end
 
+      def inspect
+        "<#{self.class} cards=#{cards}>"
+      end
+
       private
 
       def null_zone

--- a/spec/actions/ally_ability_spec.rb
+++ b/spec/actions/ally_ability_spec.rb
@@ -17,11 +17,12 @@ RSpec.describe Realms::Actions::AllyAbility do
       game.play(card1)
       expect(game.current_choice.options).to_not have_key(:"ally_ability.blob_fighter_0")
 
-      game.play(card2)
-      game.decide(game.trade_deck.trade_row.sample.key)
+      expect {
+        game.play(card2)
+        game.decide(game.trade_deck.trade_row.sample.key)
+      }.to change { game.active_turn.combat }.by(6)
 
       expect { game.ally_ability(card1) }.to change { game.active_turn.active_player.deck.hand.length }.by(1)
-      expect { game.ally_ability(card2) }.to change { game.active_turn.combat }.by(2)
 
       expect(game.current_choice.options).to_not have_key(:"ally_ability.blob_fighter_0")
       expect(game.current_choice.options).to_not have_key(:"ally_ability.battle_pod_0")

--- a/spec/actions/play_card_spec.rb
+++ b/spec/actions/play_card_spec.rb
@@ -2,24 +2,76 @@ require "spec_helper"
 
 RSpec.describe Realms::Actions::PlayCard do
   let(:game) { Realms::Game.new }
-  let(:card1) { Realms::Cards::Scout.new(game.p1, index: 10) }
-  let(:card2) { Realms::Cards::Scout.new(game.p1, index: 11) }
-  let(:card3) { Realms::Cards::Scout.new(game.p1, index: 12) }
 
   before do
-    game.p1.deck.hand << card1
-    game.p1.deck.hand << card2
-    game.p1.deck.hand << card3
+    cards.each do |card|
+      game.p1.deck.hand << card
+    end
     game.start
   end
 
-  it do
-    expect {
-      game.play(:scout_10)
-    }.to change { game.active_player.deck.hand.length }.by(-1).and \
-         change { game.active_player.deck.in_play.length }.by(1)
-    game.play(:scout_11)
-    game.play(:scout_12)
-    expect(game.active_turn.trade).to eq(3)
+  context "playing a card" do
+    let(:cards) do
+      [
+        Realms::Cards::Scout.new(game.p1, index: 10),
+        Realms::Cards::Scout.new(game.p1, index: 11),
+        Realms::Cards::Scout.new(game.p1, index: 12),
+      ]
+    end
+
+    it do
+      expect {
+        game.play(:scout_10)
+      }.to change { game.active_player.deck.hand.length }.by(-1).and \
+           change { game.active_player.deck.in_play.length }.by(1)
+      game.play(:scout_11)
+      game.play(:scout_12)
+      expect(game.active_turn.trade).to eq(3)
+    end
+  end
+
+  context "playing a card with an automatically performed ally ability" do
+    let(:cards) do
+      [
+        Realms::Cards::Corvette.new(game.p1, index: 0),
+        Realms::Cards::Corvette.new(game.p1, index: 1),
+      ]
+    end
+
+    it do
+      expect {
+        game.play(:corvette_0)
+      }.to change { game.active_turn.combat }.by(1).and \
+           change { game.active_player.draw_pile.length }.by(-1)
+      expect {
+        game.play(:corvette_1)
+      }.to change { game.active_turn.combat }.by(5).and \
+           change { game.active_player.draw_pile.length }.by(-1)
+    end
+  end
+
+  context "playing a card with manually performed ally ability" do
+    let(:cards) do
+      [
+        Realms::Cards::BlobFighter.new(game.p1, index: 0),
+        Realms::Cards::BlobFighter.new(game.p1, index: 1),
+      ]
+    end
+
+    it do
+      expect {
+        game.play(:blob_fighter_0)
+      }.to change { game.active_turn.combat }.by(3).and \
+           change { game.active_player.draw_pile.length }.by(0)
+      expect {
+        game.play(:blob_fighter_1)
+      }.to change { game.active_turn.combat }.by(3).and \
+           change { game.active_player.draw_pile.length }.by(0)
+
+      expect {
+        game.ally_ability(:blob_fighter_0)
+        game.ally_ability(:blob_fighter_1)
+      }.to change { game.active_player.draw_pile.length }.by(-2)
+    end
   end
 end

--- a/spec/cards/battle_pod_spec.rb
+++ b/spec/cards/battle_pod_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe Realms::Cards::BattlePod do
   end
 
   describe "#ally_ability" do
-    include_context "ally_ability", Realms::Cards::BlobFighter
+    include_context "automatic_ally_ability", Realms::Cards::BlobFighter
 
     it {
       expect {
+        game.play(card)
         game.decide(:none)
-        game.ally_ability(card)
-      }.to change { game.active_turn.combat }.by(2)
+      }.to change { game.active_turn.combat }.by(6)
     }
   end
 end

--- a/spec/cards/corvette_spec.rb
+++ b/spec/cards/corvette_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Realms::Cards::Corvette do
   end
 
   describe "#ally_ability" do
-    include_context "ally_ability", Realms::Cards::ImperialFighter
-    it { expect { game.ally_ability(card) }.to change { game.active_turn.combat }.by(2) }
+    include_context "automatic_ally_ability", Realms::Cards::ImperialFighter
+    it { expect { game.play(card) }.to change { game.active_turn.combat }.by(5) }
   end
 end

--- a/spec/cards/cutter_spec.rb
+++ b/spec/cards/cutter_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Realms::Cards::Cutter do
   end
 
   describe "#ally_ability" do
-    include_context "ally_ability", Realms::Cards::FederationShuttle
-    it { expect { game.ally_ability(card) }.to change { game.active_turn.combat }.by(4) }
+    include_context "automatic_ally_ability", Realms::Cards::FederationShuttle
+    it { expect { game.play(card) }.to change { game.active_turn.combat }.by(4) }
   end
 end

--- a/spec/cards/defense_center_spec.rb
+++ b/spec/cards/defense_center_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe Realms::Cards::DefenseCenter do
   end
 
   describe "#ally_ability" do
-    include_context "ally_ability", Realms::Cards::FederationShuttle
-    it { expect { game.ally_ability(card) }.to change { game.active_turn.combat }.by(2) }
+    include_context "automatic_ally_ability", Realms::Cards::FederationShuttle
+    it { expect { game.play(card) }.to change { game.active_turn.combat }.by(2) }
   end
 end
 

--- a/spec/cards/federation_shuttle_spec.rb
+++ b/spec/cards/federation_shuttle_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe Realms::Cards::FederationShuttle do
   end
 
   describe "#ally_ability" do
-    include_context "ally_ability", Realms::Cards::Cutter
+    include_context "automatic_ally_ability", Realms::Cards::Cutter
 
     it {
       expect {
-        game.ally_ability(card)
+        game.play(card)
       }.to change { game.p1.authority }.by(4)
     }
   end

--- a/spec/cards/flagship_spec.rb
+++ b/spec/cards/flagship_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Realms::Cards::Flagship do
   end
 
   describe "#ally_ability" do
-    include_context "ally_ability", Realms::Cards::FederationShuttle
-    it { expect { game.ally_ability(card) }.to change { game.p1.authority }.by(5) }
+    include_context "automatic_ally_ability", Realms::Cards::FederationShuttle
+    it { expect { game.play(card) }.to change { game.p1.authority }.by(9) }
   end
 end

--- a/spec/cards/imperial_fighter_spec.rb
+++ b/spec/cards/imperial_fighter_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Realms::Cards::ImperialFighter do
   end
 
   describe "#ally_ability" do
-    include_context "ally_ability", Realms::Cards::ImperialFighter
-    it { expect { game.ally_ability(card) }.to change { game.active_turn.combat }.by(2) }
+    include_context "automatic_ally_ability", Realms::Cards::ImperialFighter
+    it { expect { game.play(card) }.to change { game.active_turn.combat }.by(6) }
   end
 end

--- a/spec/cards/imperial_frigate_spec.rb
+++ b/spec/cards/imperial_frigate_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Realms::Cards::ImperialFrigate do
   end
 
   describe "#ally_ability" do
-    include_context "ally_ability", Realms::Cards::ImperialFighter
-    it { expect { game.ally_ability(card) }.to change { game.active_turn.combat }.by(2) }
+    include_context "automatic_ally_ability", Realms::Cards::ImperialFighter
+    it { expect { game.play(card) }.to change { game.active_turn.combat }.by(8) }
   end
 
   describe "#scrap_ability" do

--- a/spec/cards/mech_world_spec.rb
+++ b/spec/cards/mech_world_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe Realms::Cards::MechWorld do
   include_examples "cost", 5
 
   describe "#static_ability" do
-    include_context "ally_ability", Realms::Cards::Cutter
+    include_context "automatic_ally_ability", Realms::Cards::Cutter
 
     it "counts as an ally ability for all factions" do
-      expect { game.ally_ability(ally) }.to change { game.active_turn.combat }.by(4)
+      expect { game.play(card) }.to change { game.active_turn.combat }.by(4)
     end
   end
 end

--- a/spec/cards/missile_bot_spec.rb
+++ b/spec/cards/missile_bot_spec.rb
@@ -17,11 +17,13 @@ RSpec.describe Realms::Cards::MissileBot do
   end
 
   describe "#ally_ability" do
-    include_context "ally_ability", Realms::Cards::BattleStation
+    include_context "automatic_ally_ability", Realms::Cards::BattleStation
 
     it {
-      game.decide(:none)
-      expect { game.ally_ability(card) }.to change { game.active_turn.combat }.by(2)
+      expect {
+        game.play(card)
+        game.decide(:none)
+      }.to change { game.active_turn.combat }.by(4)
     }
   end
 end

--- a/spec/cards/ram_spec.rb
+++ b/spec/cards/ram_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe Realms::Cards::Ram do
   end
 
   describe "#ally_ability" do
-    include_context "ally_ability", Realms::Cards::BlobFighter
+    include_context "automatic_ally_ability", Realms::Cards::BlobFighter
     it {
       expect {
-        game.ally_ability(card)
-      }.to change { game.active_turn.combat }.by(2)
+        game.play(card)
+      }.to change { game.active_turn.combat }.by(7)
     }
   end
 

--- a/spec/cards/space_station_spec.rb
+++ b/spec/cards/space_station_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Realms::Cards::SpaceStation do
   end
 
   describe "#ally_ability" do
-    include_context "ally_ability", Realms::Cards::SurveyShip
-    it { expect { game.ally_ability(card) }.to change { game.active_turn.combat }.by(2) }
+    include_context "automatic_ally_ability", Realms::Cards::SurveyShip
+    it { expect { game.play(card) }.to change { game.active_turn.combat }.by(2) }
   end
 
   describe "#scrap_ability" do

--- a/spec/cards/stealth_needle_spec.rb
+++ b/spec/cards/stealth_needle_spec.rb
@@ -33,17 +33,10 @@ RSpec.describe Realms::Cards::StealthNeedle do
         expect {
           game.decide(another_ship.key)
         }.to change { game.active_turn.trade }.by(2).and \
-             change { game.p1.authority }.by(4)
+             change { game.p1.authority }.by(4).and \
+             change { game.active_turn.combat }.by(8)
 
         expect(card.factions).to contain_exactly(:trade_federation, :machine_cult)
-
-        expect {
-          game.ally_ability(another_ship)
-        }.to change { game.active_turn.combat }.by(4)
-
-        expect {
-          game.ally_ability(card)
-        }.to change { game.active_turn.combat }.by(4)
 
         game.end_turn
 
@@ -55,19 +48,26 @@ RSpec.describe Realms::Cards::StealthNeedle do
           another_stealth_needle = Realms::Cards::StealthNeedle.new(game.p1, index: 1)
           game.p1.hand << another_stealth_needle
 
-          expect { game.play(another_ship) }.to change { game.p1.authority }.by(4)
+          expect {
+            game.play(another_ship)
+          }.to change { game.p1.authority }.by(4).and \
+               change { game.active_turn.trade }.by(2)
 
           game.play(card)
-          expect { game.decide(another_ship.key) }.to change { game.p1.authority }.by(4)
-
-          game.play(another_stealth_needle)
-          expect { game.decide(card.key) }.to change { game.p1.authority }.by(4)
 
           expect {
-            game.ally_ability(another_ship)
-            game.ally_ability(card)
-            game.ally_ability(another_stealth_needle)
-          }.to change { game.active_turn.combat }.by(12)
+            game.decide(another_ship.key)
+          }.to change { game.p1.authority }.by(4).and \
+               change { game.active_turn.trade }.by(2)
+               change { game.active_turn.combat }.by(8)
+
+          game.play(another_stealth_needle)
+
+          expect {
+            game.decide(card.key)
+          }.to change { game.p1.authority }.by(4).and \
+               change { game.active_turn.trade }.by(2).and \
+               change { game.active_turn.combat }.by(4)
 
           game.end_turn
 

--- a/spec/cards/supply_bot_spec.rb
+++ b/spec/cards/supply_bot_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe Realms::Cards::SupplyBot do
   end
 
   describe "#ally_ability" do
-    include_context "ally_ability", Realms::Cards::BattleStation
+    include_context "automatic_ally_ability", Realms::Cards::BattleStation
 
     it {
-      game.decide(:none)
       expect {
-        game.ally_ability(card)
+        game.play(card)
+        game.decide(:none)
       }.to change { game.active_turn.combat }.by(2)
     }
   end

--- a/spec/cards/trade_bot_spec.rb
+++ b/spec/cards/trade_bot_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe Realms::Cards::TradeBot do
   end
 
   describe "#ally_ability" do
-    include_context "ally_ability", Realms::Cards::BattleStation
+    include_context "automatic_ally_ability", Realms::Cards::BattleStation
 
     it {
-      game.decide(:none)
       expect {
-        game.ally_ability(card)
+        game.play(card)
+        game.decide(:none)
       }.to change { game.active_turn.combat }.by(2)
     }
   end

--- a/spec/cards/trade_pod_spec.rb
+++ b/spec/cards/trade_pod_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe Realms::Cards::TradePod do
   end
 
   describe "#ally_ability" do
-    include_context "ally_ability", Realms::Cards::BlobFighter
+    include_context "automatic_ally_ability", Realms::Cards::BlobFighter
     it {
       expect {
-        game.ally_ability(card)
+        game.play(card)
       }.to change { game.active_turn.combat }.by(2)
     }
   end

--- a/spec/cards/war_world_spec.rb
+++ b/spec/cards/war_world_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Realms::Cards::WarWorld do
   end
 
   describe "#ally_ability" do
-    include_context "ally_ability", Realms::Cards::SurveyShip
-    it { expect { game.ally_ability(card) }.to change { game.active_turn.combat }.by(4) }
+    include_context "automatic_ally_ability", Realms::Cards::SurveyShip
+    it { expect { game.play(card) }.to change { game.active_turn.combat }.by(4) }
   end
 end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -149,3 +149,15 @@ RSpec.shared_context "ally_ability" do |ally_card_klass|
   end
 end
 
+RSpec.shared_context "automatic_ally_ability" do |ally_card_klass|
+  let(:game) { Realms::Game.new }
+  let(:card) { described_class.new(game.p1, index: 42) }
+  let(:ally) { ally_card_klass.new(game.p1) }
+
+  before do
+    game.p1.deck.hand << card
+    game.p1.deck.hand << ally
+    game.start
+    game.play(ally)
+  end
+end


### PR DESCRIPTION
For example, you shouldn’t have to tell the game that you’d like to collect 2 combat upon activating an ally ability.