### PR TITLE
Base abilities can automatically trigger

### DIFF
--- a/lib/realms/actions/play_card.rb
+++ b/lib/realms/actions/play_card.rb
@@ -7,7 +7,7 @@ module Realms
 
       def execute
         active_player.deck.play(card)
-        perform card.primary_ability if card.ship? || card.static?
+        perform card.primary_ability if card.automatic_primary_ability?
         active_player.in_play.automatic_actions.each do |action|
           perform action
         end

--- a/lib/realms/cards/card.rb
+++ b/lib/realms/cards/card.rb
@@ -146,6 +146,10 @@ module Realms
         definition.ally_abilities.any?
       end
 
+      def automatic_primary_ability?
+        ship? || static? || definition.primary_abilities.any?(&:auto?)
+      end
+
       def automatic_ally_ability?
         definition.ally_abilities.any?(&:auto?)
       end

--- a/spec/cards/space_station_spec.rb
+++ b/spec/cards/space_station_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe Realms::Cards::SpaceStation do
   include_examples "cost", 4
 
   describe "#primary_ability" do
-    include_context "base_ability"
-    it { expect { game.base_ability(card) }.to change { game.active_turn.combat }.by(2) }
+    include_context "primary_ability"
+    it { expect { game.play(card) }.to change { game.active_turn.combat }.by(2) }
   end
 
   describe "#ally_ability" do
     include_context "automatic_ally_ability", Realms::Cards::SurveyShip
-    it { expect { game.play(card) }.to change { game.active_turn.combat }.by(2) }
+    it { expect { game.play(card) }.to change { game.active_turn.combat }.by(4) }
   end
 
   describe "#scrap_ability" do

--- a/spec/cards/war_world_spec.rb
+++ b/spec/cards/war_world_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe Realms::Cards::WarWorld do
   include_examples "cost", 5
 
   describe "#primary_ability" do
-    include_context "base_ability"
-    it { expect { game.base_ability(card) }.to change { game.active_turn.combat }.by(3) }
+    include_context "primary_ability"
+    it { expect { game.play(card) }.to change { game.active_turn.combat }.by(3) }
   end
 
   describe "#ally_ability" do
     include_context "automatic_ally_ability", Realms::Cards::SurveyShip
-    it { expect { game.play(card) }.to change { game.active_turn.combat }.by(4) }
+    it { expect { game.play(card) }.to change { game.active_turn.combat }.by(7) }
   end
 end


### PR DESCRIPTION
For example, it’s silly to make a player choose
to perform the primary base ability of war world
to gain 3 combat. Instead, they should just gain
the combat when coming into play.