### PR TITLE
Push the responsibility of performing abilities into the zone

### DIFF
--- a/lib/realms/abilities/copy_ship.rb
+++ b/lib/realms/abilities/copy_ship.rb
@@ -10,7 +10,8 @@ module Realms
           card.definition = ship.definition.clone.tap do |definition|
             card.factions.each { |faction| definition.factions << faction }
           end
-          perform card.primary_ability
+          active_player.in_play.reset!(card)
+          perform active_player.in_play
         end
       end
 

--- a/lib/realms/actions/play_card.rb
+++ b/lib/realms/actions/play_card.rb
@@ -7,10 +7,7 @@ module Realms
 
       def execute
         active_player.deck.play(card)
-        perform card.primary_ability if card.automatic_primary_ability?
-        active_player.in_play.automatic_actions.each do |action|
-          perform action
-        end
+        perform active_player.in_play
       end
     end
   end

--- a/lib/realms/cards/card.rb
+++ b/lib/realms/cards/card.rb
@@ -174,6 +174,10 @@ module Realms
         type == :outpost
       end
 
+      def ally?(other)
+        (ally_factions & other.ally_factions).present?
+      end
+
       def inspect
         key
       end

--- a/lib/realms/game.rb
+++ b/lib/realms/game.rb
@@ -43,6 +43,10 @@ module Realms
       end
     end
 
+    def decide(key)
+      super(safe(key))
+    end
+
     def play(key)
       decide("play.#{safe(key)}")
     end

--- a/lib/realms/zones/zone.rb
+++ b/lib/realms/zones/zone.rb
@@ -2,7 +2,7 @@ require "realms/zones/transfer"
 
 module Realms
   module Zones
-    class Zone
+    class Zone < Yielder
       attr_accessor :owner, :cards
 
       include Enumerable

--- a/spec/actions/base_ability_spec.rb
+++ b/spec/actions/base_ability_spec.rb
@@ -2,17 +2,75 @@ require "spec_helper"
 
 RSpec.describe Realms::Actions::BaseAbility do
   let(:game) { Realms::Game.new }
-  let(:card) { Realms::Cards::BlobWheel.new(game.p1) }
   let(:action) { described_class.new(card) }
 
-  before do
-    game.p1.deck.in_play << card
-    game.start
-    game.base_ability(card)
+  context "automatically triggered base abilities" do
+    let(:card) { Realms::Cards::BlobWheel.new(game.p1) }
+
+    context "playing a base" do
+      before do
+        game.p1.deck.hand << card
+        game.start
+      end
+
+      it "automatically uses primary ability" do
+        expect {
+          game.play(card)
+        }.to change { game.active_turn.combat }.by(1)
+      end
+
+      it "cannot perform primary base ability again once automatically triggered" do
+        expect {
+          game.play(card)
+        }.to change { game.active_turn.combat }.by(1)
+        expect { game.base_ability(card) }.to raise_error(Realms::Choice::InvalidOption)
+      end
+    end
+
+    context "a base in play" do
+      it "automatically uses primary ability"
+      it "cannot perform primary base ability again once automatically triggered"
+    end
   end
 
-  it do
-    expect(game.active_turn.combat).to eq(1)
-    expect { game.base_ability(card) }.to raise_error(Realms::Choice::InvalidOption)
+  context "manually executed base abilities" do
+    let(:card) { Realms::Cards::TradingPost.new(game.p1) }
+
+    context "playing a base" do
+      before do
+        game.p1.deck.hand << card
+        game.start
+      end
+
+      it "must be explicitly chosen" do
+        game.play(card)
+        expect {
+          game.base_ability(card)
+          game.decide(:authority)
+        }.to change { game.active_player.authority }.by(1)
+      end
+    end
+
+    context "a base in play" do
+      before do
+        game.p1.deck.in_play << card
+        game.start
+      end
+
+      it "must be explicitly chosen" do
+        game.base_ability(card)
+        expect {
+          game.decide(:authority)
+        }.to change { game.active_player.authority }.by(1)
+      end
+
+      it "can only be used once" do
+        game.base_ability(card)
+        expect {
+          game.decide(:trade)
+        }.to change { game.active_turn.trade }.by(1)
+        expect { game.base_ability(card) }.to raise_error(Realms::Choice::InvalidOption)
+      end
+    end
   end
 end

--- a/spec/cards/blob_destroyer_spec.rb
+++ b/spec/cards/blob_destroyer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Realms::Cards::BlobDestroyer do
 
     it "you may destroy target base and/or and scrap a card in the trade row" do
       game.ally_ability(card)
-      game.decide(:blob_wheel_0)
+      game.decide(ally)
       expect(game.p1.deck.in_play).to_not include(ally)
       expect(game.p1.deck.discard_pile).to include(ally)
       trade_row_card = game.trade_deck.trade_row.sample

--- a/spec/cards/blob_wheel_spec.rb
+++ b/spec/cards/blob_wheel_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe Realms::Cards::BlobWheel do
   include_examples "cost", 3
 
   describe "#primary_ability" do
-    include_context "base_ability"
+    include_context "primary_ability"
     it {
       expect {
-        game.base_ability(card)
+        game.play(card)
       }.to change { game.active_turn.combat }.by(1)
     }
   end

--- a/spec/cards/central_office_spec.rb
+++ b/spec/cards/central_office_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Realms::Cards::CentralOffice do
   include_examples "cost", 7
 
   describe "#primary_ability" do
-    include_context "base_ability" do
+    include_context "primary_ability" do
       let(:selected_card) { Realms::Cards::Cutter.new(index: 10) }
       before do
         game.trade_deck.trade_row.cards[0] = selected_card
@@ -16,7 +16,7 @@ RSpec.describe Realms::Cards::CentralOffice do
 
     it {
       expect {
-        game.base_ability(card)
+        game.play(card)
       }.to change { game.active_turn.trade }.by(2)
       trade_row_card = game.trade_deck.trade_row.first
       expect {
@@ -26,7 +26,7 @@ RSpec.describe Realms::Cards::CentralOffice do
   end
 
   describe "#ally_ability" do
-    include_context "base_ability" do
+    include_context "primary_ability" do
       let(:selected_card) { Realms::Cards::Cutter.new(index: 10) }
       let(:ally_card) { Realms::Cards::FederationShuttle.new(game.p1) }
 
@@ -37,7 +37,7 @@ RSpec.describe Realms::Cards::CentralOffice do
     end
 
     it {
-      expect { game.base_ability(card) }.to change { game.active_turn.trade }.by(2)
+      expect { game.play(card) }.to change { game.active_turn.trade }.by(2)
       trade_row_card = game.trade_deck.trade_row.first
       expect {
         game.acquire(trade_row_card)

--- a/spec/cards/port_of_call_spec.rb
+++ b/spec/cards/port_of_call_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Realms::Cards::PortOfCall do
   include_examples "cost", 6
 
   describe "#primary_ability" do
-    include_context "base_ability"
+    include_context "primary_ability"
 
-    it { expect { game.base_ability(card) }.to change { game.active_turn.trade }.by(3) }
+    it { expect { game.play(card) }.to change { game.active_turn.trade }.by(3) }
   end
 
   describe "#scrap_ability" do

--- a/spec/cards/royal_redoubt_spec.rb
+++ b/spec/cards/royal_redoubt_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Realms::Cards::RoyalRedoubt do
   include_examples "cost", 6
 
   describe "#primary_ability" do
-    include_context "base_ability"
-    it { expect { game.base_ability(card) }.to change { game.active_turn.combat }.by(3) }
+    include_context "primary_ability"
+    it { expect { game.play(card) }.to change { game.active_turn.combat }.by(3) }
   end
 
   describe "#ally_ability" do

--- a/spec/cards/stealth_needle_spec.rb
+++ b/spec/cards/stealth_needle_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Realms::Cards::StealthNeedle do
         expect(game.current_choice.options.keys).to_not include(card.key)
 
         expect {
-          game.decide(another_ship.key)
+          game.decide(another_ship)
         }.to change { game.active_turn.trade }.by(2).and \
              change { game.p1.authority }.by(4).and \
              change { game.active_turn.combat }.by(8)

--- a/spec/cards/the_hive_spec.rb
+++ b/spec/cards/the_hive_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe Realms::Cards::TheHive do
   include_examples "cost", 5
 
   describe "#primary_ability" do
-    include_context "base_ability"
+    include_context "primary_ability"
     it {
       expect {
-        game.base_ability(card)
+        game.play(card)
       }.to change { game.active_turn.combat }.by(3)
     }
   end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -13,7 +13,7 @@ shared_examples "destroy_target_base" do
   end
 
   context "base in play" do
-    let(:base_card) { Realms::Cards::BlobWheel.new(game.p1) }
+    let(:base_card) { Realms::Cards::BarterWorld.new(game.p1) }
 
     def setup
       game.p1.deck.in_play << base_card
@@ -26,7 +26,7 @@ shared_examples "destroy_target_base" do
   end
 
   context "both outpost and base in play" do
-    let(:base_card) { Realms::Cards::BlobWheel.new(game.p1) }
+    let(:base_card) { Realms::Cards::BarterWorld.new(game.p1) }
     let(:outpost_card) { Realms::Cards::BattleStation.new(game.p1) }
 
     def setup
@@ -138,7 +138,7 @@ end
 RSpec.shared_context "ally_ability" do |ally_card_klass|
   let(:game) { Realms::Game.new }
   let(:card) { described_class.new(game.p1, index: 42) }
-  let(:ally) { ally_card_klass.new(game.p1) }
+  let(:ally) { ally_card_klass.new(game.p1, index: 43) }
 
   before do
     game.p1.deck.hand << card
@@ -152,7 +152,7 @@ end
 RSpec.shared_context "automatic_ally_ability" do |ally_card_klass|
   let(:game) { Realms::Game.new }
   let(:card) { described_class.new(game.p1, index: 42) }
-  let(:ally) { ally_card_klass.new(game.p1) }
+  let(:ally) { ally_card_klass.new(game.p1, index: 43) }
 
   before do
     game.p1.deck.hand << card

--- a/spec/zones/explorers_spec.rb
+++ b/spec/zones/explorers_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe Realms::Actions::AcquireCard do
+RSpec.describe Realms::Zones::Explorers do
   let(:game) { Realms::Game.new }
   let(:hand) do
     Realms::Zones::Hand.new(game.p1, 100.times.map { |i| Realms::Cards::Scout.new(game.p1, index: 10 + i) })

--- a/spec/zones/in_play_spec.rb
+++ b/spec/zones/in_play_spec.rb
@@ -1,0 +1,171 @@
+require "spec_helper"
+
+RSpec.describe Realms::Zones::InPlay do
+  context "ship" do
+    context "primary_ability" do
+      include_context "primary_ability" do
+        let(:card) { Realms::Cards::BlobFighter.new(game.p1) }
+      end
+
+      it do
+        expect {
+          game.play(card)
+        }.to change { game.active_turn.combat }.by(3)
+      end
+    end
+
+    context "ally_ability" do
+      context "manual" do
+        include_context "ally_ability", Realms::Cards::BlobFighter do
+          let(:card) { Realms::Cards::BlobFighter.new(game.p1) }
+        end
+
+        it do
+          expect {
+            game.ally_ability(card)
+            game.ally_ability(ally)
+          }.to change { game.p1.draw_pile.length }.by(-2)
+
+          expect(game.current_choice.options.keys).to_not include(:"ally_ability.#{card.key}")
+          expect(game.current_choice.options.keys).to_not include(:"ally_ability.#{ally.key}")
+        end
+      end
+
+      context "automatic" do
+        include_context "automatic_ally_ability", Realms::Cards::Corvette do
+          let(:card) { Realms::Cards::Corvette.new(game.p1) }
+        end
+
+        it do
+          expect {
+            game.play(card)
+          }.to change { game.active_turn.combat }.by(5).and \
+               change { game.p1.draw_pile.length }.by(-1)
+
+          expect(game.current_choice.options.keys).to_not include(:"ally_ability.#{card.key}")
+          expect(game.current_choice.options.keys).to_not include(:"ally_ability.#{ally.key}")
+        end
+      end
+    end
+  end
+
+  context "base" do
+    context "playing from hand" do
+      context "primary_ability" do
+        context "manual" do
+          include_context "base_ability" do
+            let(:card) { Realms::Cards::TradingPost.new(game.p1) }
+          end
+
+          it do
+            expect {
+              game.base_ability(card)
+              game.decide(:authority)
+            }.to change { game.active_player.authority }.by(1)
+            expect(game.current_choice.options.keys).to_not include(:"base_ability.#{card.key}")
+          end
+        end
+
+        context "automatic" do
+          include_context "primary_ability" do
+            let(:card) { Realms::Cards::BlobWheel.new(game.p1) }
+          end
+
+          it do
+            expect {
+              game.play(card)
+            }.to change { game.active_turn.combat }.by(1)
+            expect(game.current_choice.options.keys).to_not include(:"base_ability.#{card.key}")
+          end
+        end
+      end
+
+      context "ally_ability" do
+        context "manual" do
+          include_context "ally_ability", Realms::Cards::BlobFighter do
+            let(:card) { Realms::Cards::TheHive.new(game.p1) }
+          end
+
+          it do
+            expect {
+              game.ally_ability(card)
+            }.to change { game.p1.draw_pile.length }.by(-1)
+            expect(game.current_choice.options.keys).to_not include(:"ally_ability.#{card.key}")
+          end
+        end
+
+        context "automatic" do
+          include_context "automatic_ally_ability", Realms::Cards::Corvette do
+            let(:card) { Realms::Cards::WarWorld.new(game.p1) }
+          end
+
+          it do
+            expect {
+              game.play(card)
+            }.to change { game.active_turn.combat }.by(9)
+            expect(game.current_choice.options.keys).to_not include(:"ally_ability.#{card.key}")
+          end
+        end
+      end
+    end
+
+    xcontext "already in play" do
+      context "primary_ability" do
+        context "manual" do
+          include_context "base_ability" do
+            let(:card) { Realms::Cards::TradingPost.new(game.p1) }
+          end
+
+          it do
+            expect {
+              game.base_ability(card)
+              game.decide(:authority)
+            }.to change { game.active_player.authority }.by(1)
+            expect(game.current_choice.options.keys).to_not include(:"base_ability.#{card.key}")
+          end
+        end
+
+        context "automatic" do
+          include_context "primary_ability" do
+            let(:card) { Realms::Cards::BlobWheel.new(game.p1) }
+          end
+
+          it do
+            expect {
+              game.play(card)
+            }.to change { game.active_turn.combat }.by(1)
+            expect(game.current_choice.options.keys).to_not include(:"base_ability.#{card.key}")
+          end
+        end
+      end
+
+      context "ally_ability" do
+        context "manual" do
+          include_context "ally_ability", Realms::Cards::BlobFighter do
+            let(:card) { Realms::Cards::TheHive.new(game.p1) }
+          end
+
+          it do
+            expect {
+              game.ally_ability(card)
+            }.to change { game.p1.draw_pile.length }.by(-1)
+            expect(game.current_choice.options.keys).to_not include(:"ally_ability.#{card.key}")
+          end
+        end
+
+        context "automatic" do
+          include_context "automatic_ally_ability", Realms::Cards::Corvette do
+            let(:card) { Realms::Cards::WarWorld.new(game.p1) }
+          end
+
+          it do
+            expect {
+              game.play(card)
+            }.to change { game.active_turn.combat }.by(9)
+            expect(game.current_choice.options.keys).to_not include(:"ally_ability.#{card.key}")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This shifts responsibility from the action to the zone. Now the action
is simply responsible for performing the zone transfer into the "in
play" zone. This is convenient because the in play zone maintains a
shadow collection of "in play state" that it can use to determine what
abilities are performed automatically as a result of the player telling
the game that they would like to play a card.

There was a little bit of weirdness for cards that become other cards,
such as stealth needle. I decided to handle this by adding a small
amount of interface to zone. The method Zone#reset!(card) is a hook that
instructs the zone to re-evaluate the in play state after an ability
like copy ship that effectively replays the card.