### PR TITLE
move state machine responsibility out of zone

### DIFF
--- a/lib/realms/abilities/copy_ship.rb
+++ b/lib/realms/abilities/copy_ship.rb
@@ -10,8 +10,10 @@ module Realms
           card.definition = ship.definition.clone.tap do |definition|
             card.factions.each { |faction| definition.factions << faction }
           end
-          active_player.in_play.reset!(card)
-          perform active_player.in_play
+          perform card.primary_ability(turn)
+          active_player.in_play.actions.select(&:auto?).each do |action|
+            perform action
+          end
         end
       end
 

--- a/lib/realms/actions/play_card.rb
+++ b/lib/realms/actions/play_card.rb
@@ -7,7 +7,10 @@ module Realms
 
       def execute
         active_player.play(card)
-        perform active_player.in_play
+        perform card.primary_ability(turn) if card.automatic_primary_ability?
+        active_player.in_play.actions.select(&:auto?).each do |action|
+          perform action
+        end
       end
     end
   end

--- a/lib/realms/cards/card.rb
+++ b/lib/realms/cards/card.rb
@@ -5,6 +5,8 @@ require "equalizer"
 module Realms
   module Cards
     class Card
+      include Brainguy::Observable
+
       module Factions
         ALL = [
           BLOB = :blob,
@@ -131,11 +133,20 @@ module Realms
       end
 
       def primary_ability(turn)
-        definition.primary_ability.new(self, turn)
+        definition.primary_ability.new(self, turn).tap do
+          emit(:primary_ability, self)
+        end
       end
 
       def ally_ability(turn)
-        definition.ally_ability.new(self, turn)
+        definition.ally_ability.new(self, turn).tap do
+          emit(:ally_ability, self)
+        end
+      end
+
+      def definition=(definition)
+        @definition = definition
+        emit(:definition_change, self)
       end
 
       def scrap_ability(turn)
@@ -187,6 +198,7 @@ module Realms
       end
 
       def ally?(other)
+        return false if self == other
         (ally_factions & other.ally_factions).present?
       end
 

--- a/lib/realms/phases/discard.rb
+++ b/lib/realms/phases/discard.rb
@@ -7,7 +7,6 @@ module Realms
         active_player.in_play.select(&:ship?).each do |ship|
           active_player.destroy(ship)
         end
-        active_player.in_play.cards_in_play.select(&:base?).each { |base| base.reset! }
         active_player.discard_hand
       end
     end

--- a/lib/realms/phases/draw.rb
+++ b/lib/realms/phases/draw.rb
@@ -2,7 +2,8 @@ module Realms
   module Phases
     class Draw < Phase
       def execute
-        turn.active_player.draw(5)
+        active_player.draw(5)
+        active_player.in_play.reset!
       end
     end
   end

--- a/lib/realms/zones/zone.rb
+++ b/lib/realms/zones/zone.rb
@@ -2,7 +2,7 @@ require "realms/zones/transfer"
 
 module Realms
   module Zones
-    class Zone < Yielder
+    class Zone
       attr_accessor :owner, :cards
 
       include Enumerable

--- a/spec/actions/acquire_card_spec.rb
+++ b/spec/actions/acquire_card_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Realms::Actions::AcquireCard do
   end
 
   context "when the turn doesn't have enough trade" do
-    let(:trade_row_card) { Realms::Cards::BlobWheel.new(game.trade_deck) }
+    let(:trade_row_card) { Realms::Cards::BlobWheel.new(game.trade_deck, index: 42) }
     let(:cards_in_hand) do
       [
         game.p1.scout,
@@ -50,8 +50,8 @@ RSpec.describe Realms::Actions::AcquireCard do
       }.to change { game.active_turn.trade }.by(2).and \
            change { game.active_turn.combat }.by(1)
 
-      expect(game.current_choice.options).to have_key(:"acquire.explorer_0")
-      expect(game.current_choice.options.keys).to_not include(:"acquire.#{trade_row_card.key}")
+      expect(game.current_choice).to have_option(:acquire, :explorer_0)
+      expect(game.current_choice).to_not have_option(:acquire, trade_row_card)
     end
   end
 end

--- a/spec/actions/ally_ability_spec.rb
+++ b/spec/actions/ally_ability_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Realms::Actions::AllyAbility do
 
     it "triggers both cards" do
       game.play(card1)
-      expect(game.current_choice.options).to_not have_key(:"ally_ability.blob_fighter_0")
+      expect(game.current_choice).to_not have_option(:ally_ability, card1)
 
       expect {
         game.play(card2)

--- a/spec/cards/stealth_needle_spec.rb
+++ b/spec/cards/stealth_needle_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Realms::Cards::StealthNeedle do
              change { game.active_player.authority }.by(4)
 
         game.play(card)
-        expect(game.current_choice.options.keys).to_not include(card.key)
+        expect(game.current_choice).to_not have_option(:copy_ship, card)
 
         expect {
           game.decide(:copy_ship, another_ship)

--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -1,0 +1,16 @@
+require 'rspec/expectations'
+
+RSpec::Matchers.define :have_option do |action, target|
+  match do |actual|
+    expect(actual.options.keys).to include(key(action, target))
+  end
+
+  failure_message do |actual|
+    "expected #{actual.options.keys} to include #{key(action, target)}"
+  end
+
+  def key(action, target)
+    key = target.respond_to?(:key) ? target.key : target
+    [action, key].compact.join(".").to_sym
+  end
+end

--- a/spec/zones/in_play_spec.rb
+++ b/spec/zones/in_play_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Realms::Zones::InPlay do
             game.ally_ability(ally)
           }.to change { game.active_player.draw_pile.length }.by(-2)
 
-          expect(game.current_choice.options.keys).to_not include(:"ally_ability.#{card.key}")
-          expect(game.current_choice.options.keys).to_not include(:"ally_ability.#{ally.key}")
+          expect(game.current_choice).to_not have_option(:ally_ability, card)
+          expect(game.current_choice).to_not have_option(:ally_ability, ally)
         end
       end
 
@@ -42,8 +42,8 @@ RSpec.describe Realms::Zones::InPlay do
           }.to change { game.active_turn.combat }.by(5).and \
                change { game.active_player.draw_pile.length }.by(-1)
 
-          expect(game.current_choice.options.keys).to_not include(:"ally_ability.#{card.key}")
-          expect(game.current_choice.options.keys).to_not include(:"ally_ability.#{ally.key}")
+          expect(game.current_choice).to_not have_option(:ally_ability, card)
+          expect(game.current_choice).to_not have_option(:ally_ability, ally)
         end
       end
     end
@@ -62,7 +62,7 @@ RSpec.describe Realms::Zones::InPlay do
               game.base_ability(card)
               game.decide(:trading_post, :authority)
             }.to change { game.active_player.authority }.by(1)
-            expect(game.current_choice.options.keys).to_not include(:"base_ability.#{card.key}")
+            expect(game.current_choice).to_not have_option(:base_ability, card)
           end
         end
 
@@ -75,7 +75,7 @@ RSpec.describe Realms::Zones::InPlay do
             expect {
               game.play(card)
             }.to change { game.active_turn.combat }.by(1)
-            expect(game.current_choice.options.keys).to_not include(:"base_ability.#{card.key}")
+            expect(game.current_choice).to_not have_option(:base_ability, card)
           end
         end
       end
@@ -90,7 +90,7 @@ RSpec.describe Realms::Zones::InPlay do
             expect {
               game.ally_ability(card)
             }.to change { game.active_player.draw_pile.length }.by(-1)
-            expect(game.current_choice.options.keys).to_not include(:"ally_ability.#{card.key}")
+            expect(game.current_choice).to_not have_option(:ally_ability, card)
           end
         end
 
@@ -103,7 +103,7 @@ RSpec.describe Realms::Zones::InPlay do
             expect {
               game.play(card)
             }.to change { game.active_turn.combat }.by(9)
-            expect(game.current_choice.options.keys).to_not include(:"ally_ability.#{card.key}")
+            expect(game.current_choice).to_not have_option(:ally_ability, card)
           end
         end
       end
@@ -121,7 +121,7 @@ RSpec.describe Realms::Zones::InPlay do
               game.base_ability(card)
               game.decide(:authority)
             }.to change { game.active_player.authority }.by(1)
-            expect(game.current_choice.options.keys).to_not include(:"base_ability.#{card.key}")
+            expect(game.current_choice).to_not have_option(:base_ability, card)
           end
         end
 
@@ -134,7 +134,7 @@ RSpec.describe Realms::Zones::InPlay do
             expect {
               game.play(card)
             }.to change { game.active_turn.combat }.by(1)
-            expect(game.current_choice.options.keys).to_not include(:"base_ability.#{card.key}")
+            expect(game.current_choice).to_not have_option(:base_ability, card)
           end
         end
       end
@@ -149,7 +149,7 @@ RSpec.describe Realms::Zones::InPlay do
             expect {
               game.ally_ability(card)
             }.to change { game.active_player.draw_pile.length }.by(-1)
-            expect(game.current_choice.options.keys).to_not include(:"ally_ability.#{card.key}")
+            expect(game.current_choice).to_not have_option(:ally_ability, card)
           end
         end
 
@@ -162,7 +162,7 @@ RSpec.describe Realms::Zones::InPlay do
             expect {
               game.play(card)
             }.to change { game.active_turn.combat }.by(9)
-            expect(game.current_choice.options.keys).to_not include(:"ally_ability.#{card.key}")
+            expect(game.current_choice).to_not have_option(:ally_ability, card)
           end
         end
       end


### PR DESCRIPTION
After talking through this, it seems like a breach of responsibility.

The zone’s execute method never paused for player interaction, so it seems its kind of abuse of the state machine.

However, I can see in a more complicated game a scenario where there is player interaction that needs to be resolved before a card finished being played. In that case I think there’s actually a transient zone in between playing the card and the card resolving.

Supports #38 