### PR TITLE
Refactor Zone Registry into configurable Layout

### DIFF
--- a/lib/realms/actions.rb
+++ b/lib/realms/actions.rb
@@ -6,5 +6,81 @@ end
 
 module Realms
   module Actions
+    def self.actions
+      @actions ||= Registry.configure do
+        action(:play) do
+          targets { active_player.hand }
+          execution { |card| active_player.play(card) }
+        end
+
+        action(:attack) do
+          targets do
+            eligible = ->(base) { active_player.combat >= base.defense }
+            passive_players.each_with_object([]) do |passive_player, targets|
+              outposts, bases = passive_player.in_play.select(&:base?).partition(&:outpost?)
+              if outposts.any?
+                targets.concat(outposts.select(&eligible))
+              else
+                targets.concat(bases.select(&eligible))
+                targets << passive_player if active_player.combat.positive?
+              end
+            end
+          end
+          execution do |target|
+            if passive_players.include?(target)
+              target.authority -= active_player.combat.value
+              active_player.combat = 0
+            else
+              active_player.combat -= target.defense
+              target.owner.destroy(target)
+            end
+          end
+        end
+
+        action(:acquire) do
+          targets do
+            layout.trade_row.select do |card|
+              card.cost <= active_player.trade.value
+            end
+          end
+          execution do |card|
+            active_player.trade -= card.cost
+            active_player.acquire(card)
+          end
+        end
+
+        action(:primary_ability) do
+          targets do
+            active_player.in_play.each_with_object([]) do |card, abilities|
+              abilities << card.primary_ability if card.primary_ability.eligible?
+            end
+          end
+          execution { |ability| perform(ability) }
+        end
+
+        action(:scrap_ability) do
+          targets do
+            active_player.in_play.each_with_object([]) do |card, abilities|
+              abilities << card.scrap_ability if card.scrap_ability.eligible?
+            end
+          end
+          execution do |ability|
+            active_player.scrap(ability.card)
+            perform(ability)
+          end
+        end
+
+        action(:ally_ability) do
+          targets do
+            active_player.in_play.each_with_object([]) do |card, abilities|
+              abilities << card.ally_ability if card.ally_ability.eligible?
+            end
+          end
+          execution { |ability| perform(ability) }
+        end
+
+        action(:end_turn)
+      end
+    end
   end
 end

--- a/lib/realms/actions/registry.rb
+++ b/lib/realms/actions/registry.rb
@@ -1,0 +1,90 @@
+module Realms
+  module Actions
+    class Registry
+      def self.configure(&block)
+        registry = new
+        registry.instance_exec(&block)
+        registry
+      end
+
+      attr_reader :configs
+
+      delegate :slice,
+        to: :configs
+
+      def initialize
+        @configs = {}
+      end
+
+      def action(key, &config)
+        builder = Builder.new(key: key)
+        builder.instance_exec(&config) if block_given?
+        @configs.merge!(key => builder.to_definition) do |_|
+          raise("#{key} is already registered")
+        end
+      end
+
+      class Builder
+        attr_accessor :key, :targeting, :execution
+
+        def initialize(key:)
+          @key = key
+          @targeting = -> { [] }
+          @execution = -> { false }
+        end
+
+        def targets(&block)
+          @targeting = block
+        end
+
+        def execution(&block)
+          @execution = block
+        end
+
+        def to_definition
+          Definition.new(key: key, targeting: targeting, execution: execution)
+        end
+      end
+
+      class Definition
+        attr_reader :key, :targeting, :execution
+
+        def initialize(key:, targeting:, execution:)
+          @key = key
+          @targeting = targeting
+          @execution = execution
+        end
+
+        def evaluate(context, target)
+          Evaluated.new(self, context, target)
+        end
+
+        class Evaluated
+          attr_reader :definition, :context, :target
+
+          delegate :active_player, :passive_players,
+            to: :context
+
+          def initialize(definition, context, target)
+            @definition = definition
+            @context = context
+            @target = target
+          end
+
+          def eligible?
+            true
+          end
+
+          def key
+            [definition.key, target.key].join(".")
+          end
+
+          def execute
+            return unless definition.execution
+            instance_exec(&definition.execution)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/realms/card_pools.rb
+++ b/lib/realms/card_pools.rb
@@ -1,5 +1,7 @@
 require "realms/card_pools/card_pool"
 require "realms/card_pools/vanilla"
+require "realms/card_pools/starter_deck"
+require "realms/card_pools/explorers"
 
 module Realms
   module CardPools

--- a/lib/realms/card_pools/explorers.rb
+++ b/lib/realms/card_pools/explorers.rb
@@ -1,0 +1,7 @@
+module Realms
+  module CardPools
+    class Explorers < CardPool
+      card Explorer, 100
+    end
+  end
+end

--- a/lib/realms/card_pools/starter_deck.rb
+++ b/lib/realms/card_pools/starter_deck.rb
@@ -1,0 +1,8 @@
+module Realms
+  module CardPools
+    class StarterDeck < CardPool
+      card Scout, 8
+      card Viper, 2
+    end
+  end
+end

--- a/lib/realms/cards/card.rb
+++ b/lib/realms/cards/card.rb
@@ -56,7 +56,7 @@ module Realms
       class AbilityContext
         attr_reader :game, :card
 
-        delegate :active_turn, :active_player, :choose,
+        delegate :active_turn, :choose,
           :to => :game
 
         def initialize(card:, game:)

--- a/lib/realms/effects.rb
+++ b/lib/realms/effects.rb
@@ -102,9 +102,8 @@ module Realms
         end
 
         effect(:acquire_ship_and_top_deck) do
-          trade_row_ships = trade_row.select(&:ship?)
-          choose(trade_row_ships) do |card|
-            active_player.acquire(card, zone: active_player.draw_pile, pos: 0)
+          choose(trade_row.select(&:ship?)) do |card|
+            trade_row.transfer!(card: card, to: active_player.draw_pile, pos: 0)
           end
         end
 

--- a/lib/realms/flows/declarations/loop.rb
+++ b/lib/realms/flows/declarations/loop.rb
@@ -24,12 +24,16 @@ module Realms
           def initialize(declaration, context)
             @declaration = declaration
             @context = context
+            @active_declaration = nil
           end
 
+          # TODO: There's probably a "round" that uses loop
           def execute
-            declaration.declarations.cycle do |declaration|
-              phase = declaration.evaluate(context) 
-              game.perform(phase)
+            context.layout.players.cycle do |active_player|
+              declaration.declarations.each do |declaration|
+                phase = declaration.evaluate(context, active_player) 
+                game.perform(phase)
+              end
             end
           end
         end

--- a/lib/realms/flows/declarations/sequence.rb
+++ b/lib/realms/flows/declarations/sequence.rb
@@ -19,8 +19,6 @@ module Realms
         class Evaluated
           attr_reader :declaration, :context
 
-          delegate :game, to: :context
-
           def initialize(declaration, context)
             @declaration = declaration
             @context = context
@@ -28,8 +26,12 @@ module Realms
 
           def execute
             declaration.declarations.each do |declaration|
+              begin
               effect = declaration.evaluate(context) 
-              game.perform(effect)
+              context.perform(effect)
+              rescue => e
+                binding.pry
+              end
             end
           end
         end

--- a/lib/realms/game.rb
+++ b/lib/realms/game.rb
@@ -21,8 +21,8 @@ module Realms
       registry.register!
       @flows = []
       @fiber = Fiber.new { execute }
-      @turn_structure = Turns.structure.evaluate(GameContext.new(game: self))
       @layout = Zones.layout.make(GameContext.new(game: self))
+      @turn_structure = Turns.structure.evaluate(GameContext.new(game: self))
       @game_over = false
     end
 

--- a/lib/realms/game.rb
+++ b/lib/realms/game.rb
@@ -4,26 +4,29 @@ require "realms/turn"
 
 module Realms
   class Game
-    attr_reader :seed, :registry, :event_counter, :active_turn
+    attr_reader :seed, :event_counter, :active_turn
 
-    delegate :active_player, :passive_player,
-      to: :active_turn, allow_nil: true
-
-    delegate :p1, :p2, :trade_deck,
-      to: :registry
+    delegate :active_player,
+      to: :turn_structure
 
     attr_reader :fiber, :flows, :turn_structure, :layout
 
     def initialize(seed: Random.new_seed)
       @seed = seed
-      @registry = Zones::Registry.new(self)
       @event_counter = (0...Float::INFINITY).lazy
-      registry.register!
       @flows = []
       @fiber = Fiber.new { execute }
       @layout = Zones.layout.make(GameContext.new(game: self))
-      @turn_structure = Turns.structure.evaluate(GameContext.new(game: self))
+      @turn_structure = Turns.structure.evaluate(layout)
       @game_over = false
+    end
+
+    def p1
+      layout.perspectives.fetch("p1")
+    end
+
+    def p2
+      layout.perspectives.fetch("p2")
     end
 
     def over?
@@ -86,13 +89,14 @@ module Realms
       include Brainguy::Observer
       include Brainguy::Observable
 
-      attr_reader :game
+      attr_reader :game, :rng
 
-      delegate :active_turn, :active_player, :choose,
+      delegate :active_turn, :choose,
         :to => :game
 
       def initialize(game:)
         @game = game
+        @rng = Random.new(game.seed)
       end
 
       def emit(*args)

--- a/lib/realms/game.rb
+++ b/lib/realms/game.rb
@@ -12,7 +12,7 @@ module Realms
     delegate :p1, :p2, :trade_deck,
       to: :registry
 
-    attr_reader :fiber, :flows, :turn_structure
+    attr_reader :fiber, :flows, :turn_structure, :layout
 
     def initialize(seed: Random.new_seed)
       @seed = seed
@@ -22,6 +22,7 @@ module Realms
       @flows = []
       @fiber = Fiber.new { execute }
       @turn_structure = Turns.structure.evaluate(GameContext.new(game: self))
+      @layout = Zones.layout.make(GameContext.new(game: self))
       @game_over = false
     end
 

--- a/lib/realms/player.rb
+++ b/lib/realms/player.rb
@@ -36,13 +36,6 @@ module Realms
       registry.viper(self)
     end
 
-    # TODO:
-    # delegate :hand, :discard_pile, :in_play, :draw_pile,
-    #   to: :player_zones
-    #
-    # delegate :trade_row, :scrap_heap, :explorers,
-    #   to: :trade_deck_zones
-
     def discard(card)
       hand.transfer!(card: card, to: discard_pile)
     end

--- a/lib/realms/turns/builder.rb
+++ b/lib/realms/turns/builder.rb
@@ -7,8 +7,8 @@ module Realms
     class Builder
       include Flows::Builder
 
-      def phase(key, &execution)
-        definition = Phases::Definition.new(key: key, execution: execution)
+      def phase(key, actions: [], &execution)
+        definition = Phases::Definition.new(key: key, actions: actions, execution: execution)
         declarations << Declarations::Phase.new(definition: definition)
       end
 

--- a/lib/realms/turns/phases/definition.rb
+++ b/lib/realms/turns/phases/definition.rb
@@ -2,11 +2,12 @@ module Realms
   module Turns
     module Phases
       class Definition
-        attr_reader :key, :execution
+        attr_reader :key, :execution, :actions
 
-        def initialize(key:, execution:)
+        def initialize(key:, actions:, execution:)
           @key = key
           @execution = execution
+          @actions = actions
         end
       end
     end

--- a/lib/realms/zones.rb
+++ b/lib/realms/zones.rb
@@ -11,75 +11,159 @@ require "realms/zones/scrap_heap"
 
 module Realms
   module Zones
-    def self.layout
-      @layout ||= Builder.build do
-        # TODO: add default card pools to zones
+    module Config
+      class Players
+        attr_reader :zones, :resources
 
-        shared do
-          zone(:trade_deck)
-          zone(:trade_row)
-          zone(:explorers)
-          zone(:scrap_heap)
+        def initialize
+          @zones = {}
+          @resources = {}
         end
 
-        players do
-          resource(:trade, default: 0)
-          resource(:combat, default: 0)
-          resource(:authority, default: 50)
+        def resource(key, **kwargs)
+          @resources[key] = Resource.new(key: key, shared: false, **kwargs)
+        end
 
-          # NOTE: push zone specific card state into card since the kind of state
-          #       seems like it would vary based on the kind of card.
-          #       Maybe there are defaults like age, played this turn, etc
-          zone(:hand)
-          zone(:in_play)
-          zone(:discard_pile)
-          zone(:draw_pile)
+        def zone(key, **kwargs, &config)
+          @zones[key] = Zone.new(key: key, shared: false, **kwargs)
+        end
 
-          # helpers do
-          #   def discard(card)
-          #     hand.transfer!(card: card, to: discard_pile)
-          #   end
+        def evaluate(context)
+          Evaluated.new(self, context)
+        end
 
-          #   def play(card)
-          #     hand.transfer!(card: card, to: in_play)
-          #   end
+        class Evaluated
+          attr_reader :config, :context
 
-          #   def destroy(card)
-          #     in_play.transfer!(card: card, to: discard_pile)
-          #   end
+          def initialize(config, context)
+            @config = config
+            @context = context
+          end
 
-          #   def acquire(card, zone: discard_pile, pos: 0)
-          #     card.zone.transfer!(card: card, to: zone, pos: pos)
-          #   end
+          def zones
+            @zones ||= players.each_with_object([]) do |player, zones|
+              config.zones.each do |_, zone_config|
+                zones << Layouts::Zone.new(owner: player, definition: zone_config)
+              end
+            end
+          end
 
-          #   def scrap(card)
-          #     card.zone.transfer!(card: card, to: scrap_heap)
-          #   end
+          def resources
+            @resources ||= players.each_with_object([]) do |player, resources|
+              config.resources.each do |_, resource_config|
+                resources << Layouts::Resource.new(owner: player, definition: resource_config)
+              end
+            end
+          end
 
-          #   def discard_hand
-          #     until hand.empty?
-          #       discard(hand.first)
-          #     end
-          #   end
+          private
 
-          #   def draw(num = 1)
-          #     num.times do
-          #       if draw_pile.empty?
-          #         reshuffle
-          #         draw unless draw_pile.empty?
-          #       else
-          #         draw_pile.transfer!(to: hand)
-          #       end
-          #     end
-          #   end
+          # TODO: GameContext should define players
+          Player = Struct.new(:key)
+          def players
+            [Player.new("p1"), Player.new("p2")]
+          end
+        end
+      end
 
-          #   def reshuffle
-          #     until discard_pile.empty? do
-          #       discard_pile.transfer!(to: draw_pile)
-          #     end
-          #     draw_pile.shuffle!(random: registry.rng)
-          #   end
-          # end
+      class Shared
+        attr_reader :zones, :resources
+
+        def initialize
+          @zones = {}
+          @resources = {}
+        end
+
+        def zone(key, **kwargs)
+          @zones[key] = Zone.new(key: key, shared: true, **kwargs)
+        end
+
+        def resource(key, default:)
+          @resources[key] = Resource.new(key: key, default: default, shared: true)
+        end
+
+        def evaluate(context)
+          Evaluated.new(self, context)
+        end
+
+        class Evaluated
+          attr_reader :config, :context
+
+          def initialize(config, context)
+            @config = config
+            @context = context
+          end
+
+          def zones
+            @zones ||= config.zones.each_with_object([]) do |(_, zone_config), zones|
+              zones << Layouts::Zone.new(owner: noone, definition: zone_config)
+            end
+          end
+
+          def resources
+            @resources ||= config.resources.each_with_object([]) do |(_, resource_config), resources|
+              resources << Layouts::Resources.new(owner: noone, definition: resource_config)
+            end
+          end
+
+          private
+
+          Noone = Struct.new(:key)
+
+          def noone
+            @noone ||= Noone.new("shared")
+          end
+        end
+      end
+
+      class Zone
+        attr_reader :key
+
+        def initialize(key:, public: false, shared: false, ordered: false)
+          @key = key
+          @public = public
+          @shared = shared
+          @ordered = ordered
+          @states = {}
+        end
+
+        def state(key, **kwargs)
+          @states[key] = ZoneCardState.new(key: key, **kwargs)
+        end
+
+        def public?
+          !!@public
+        end
+
+        def shared?
+          !!@shared
+        end
+
+        def ordered?
+          !!@ordered
+        end
+      end
+
+      class Resource
+        attr_reader :key, :default
+
+        def initialize(key:, default:, shared: false)
+          @key = key
+          @default = default
+          @shared = shared
+        end
+
+        def shared?
+          !!@shared
+        end
+      end
+
+      class ZoneCardState
+        attr_reader :key, :default
+
+        def initialize(key:, default:)
+          @key = key
+          @default = default
         end
       end
     end
@@ -109,214 +193,136 @@ module Realms
         end
       end
 
+      # TODO: I think should just enforce all the config be unique at top level
+      def item_definitions
+        @item_definitions ||= perspectives.each_with_object([]) do |(key, config), all|
+          config.zones.values.each do |z|
+            all << z
+          end
+          config.resources.values.each do |r|
+            all << r
+          end
+        end
+      end
+
       def make(context)
         evaluated_shared = perspectives[:shared].evaluate(context)
         evaluated_players = perspectives[:players].evaluate(context)
 
+        # TODO: any reason to keep them separate -- should we just enforce uniq keys
         Layouts::Layout.new(
           :zones => (evaluated_shared.zones + evaluated_players.zones).index_by(&:key),
           :resources => (evaluated_shared.resources + evaluated_players.resources).index_by(&:key)
         )
       end
+    end
 
-      module Layouts
-        class Layout
-          attr_reader :zones, :resources
+    def self.layout
+      @layout ||= Builder.build do
+        # TODO: add default card pools to zones
 
-          def initialize(zones:, resources:)
-            @zones = zones
-            @resources = resources
-          end
-
-          # TODO: player layout perspectives?
+        shared do
+          zone(:trade_deck)
+          zone(:trade_row)
+          zone(:explorers)
+          zone(:scrap_heap)
         end
 
-        class Zone
-          include Brainguy::Observer
-          include Brainguy::Observable
+        players do
+          resource(:trade, default: 0)
+          resource(:combat, default: 0)
+          resource(:authority, default: 50)
 
-          attr_reader :owner, :definition
+          # NOTE: push zone specific card state into card since the kind of state
+          #       seems like it would vary based on the kind of card.
+          #       Maybe there are defaults like age, played this turn, etc
+          zone(:hand)
+          zone(:in_play)
+          zone(:discard_pile)
+          zone(:draw_pile)
+        end
+      end
+    end
 
-          def initialize(owner:, definition:, cards: [])
-            @owner = owner
-            @definition = definition
-            @cards = []
-          end
+    module Layouts
+      class Layout
+        attr_reader :zones, :resources
 
-          def key
-            [owner.key, definition.key].join(".")
-          end
-
-          def inspect
-            "<#{key} cards=#{cards}>"
-          end
-
-          # TODO: copy over other stuff from legacy Zone base class
+        def initialize(zones:, resources:)
+          @zones = zones
+          @resources = resources
         end
 
-        class Resource
-          attr_reader :owner, :definition
+        def perspective(owner)
+          perspectives.fetch(owner.key)
+        end
 
-          def initialize(owner:, definition:)
+        # TODO: get rid of the separation
+        def items
+          @items ||= zones.merge(resources)
+        end
+
+        def perspectives
+          @perspectives ||= zones.values.map(&:owner).uniq.each_with_object({}) do |owner, all|
+            all[owner.key] = Perspective.new(layout: self, owner: owner)
+          end
+        end
+
+        class Perspective
+          attr_reader :layout, :owner
+
+          def initialize(layout:, owner:)
+            @layout = layout
             @owner = owner
-            @definition = definition
           end
 
-          def key
-            [owner.key, definition.key].join(".")
+          Zones.layout.item_definitions.each do |definition|
+            if definition.shared?
+              define_method(definition.key) do
+                layout.items.fetch([:shared, definition.key].join("."))
+              end
+            else
+              define_method(definition.key) do
+                layout.items.fetch([owner.key, definition.key].join("."))
+              end
+            end
           end
         end
       end
 
-      module Config
-        class Players
-          attr_reader :zones, :resources
+      class Zone
+        include Brainguy::Observer
+        include Brainguy::Observable
 
-          def initialize
-            @zones = {}
-            @resources = {}
-          end
+        attr_reader :owner, :definition
 
-          def resource(key, **kwargs)
-            @resources[key] = Resource.new(key: key, **kwargs)
-          end
-
-          def zone(key, **kwargs, &config)
-            @zones[key] = Zone.new(key: key, **kwargs)
-          end
-
-          def evaluate(context)
-            Evaluated.new(self, context)
-          end
-
-          class Evaluated
-            attr_reader :config, :context
-
-            def initialize(config, context)
-              @config = config
-              @context = context
-            end
-
-            def zones
-              @zones ||= players.each_with_object([]) do |player, zones|
-                config.zones.each do |_, zone_config|
-                  zones << Layouts::Zone.new(owner: player, definition: zone_config)
-                end
-              end
-            end
-
-            def resources
-              @resources ||= players.each_with_object([]) do |player, resources|
-                config.resources.each do |_, resource_config|
-                  resources << Layouts::Resource.new(owner: player, definition: resource_config)
-                end
-              end
-            end
-
-            private
-
-            # TODO: GameContext should define players
-            Player = Struct.new(:key)
-            def players
-              [Player.new("p1"), Player.new("p2")]
-            end
-          end
+        def initialize(owner:, definition:, cards: [])
+          @owner = owner
+          @definition = definition
+          @cards = []
         end
 
-        class Shared
-          attr_reader :zones, :resources
-
-          def initialize
-            @zones = {}
-            @resources = {}
-          end
-
-          def zone(key, **kwargs)
-            @zones[key] = Zone.new(key: key, **kwargs)
-          end
-
-          def resource(key, default:)
-            @resources[key] = Resource.new(key: key, default: default)
-          end
-
-          def evaluate(context)
-            Evaluated.new(self, context)
-          end
-
-          class Evaluated
-            attr_reader :config, :context
-
-            def initialize(config, context)
-              @config = config
-              @context = context
-            end
-
-            def zones
-              @zones ||= config.zones.each_with_object([]) do |(_, zone_config), zones|
-                zones << Layouts::Zone.new(owner: noone, definition: zone_config)
-              end
-            end
-
-            def resources
-              @resources ||= config.resources.each_with_object([]) do |(_, resource_config), resources|
-                resources << Layouts::Resources.new(owner: noone, definition: resource_config)
-              end
-            end
-
-            private
-
-            Noone = Struct.new(:key)
-
-            def noone
-              @noone ||= Noone.new("shared")
-            end
-          end
+        def key
+          [owner.key, definition.key].join(".")
         end
 
-        class Zone
-          attr_reader :key
-
-          def initialize(key:, public: false, shared: false, ordered: false)
-            @key = key
-            @public = public
-            @shared = shared
-            @ordered = ordered
-            @states = {}
-          end
-
-          def state(key, **kwargs)
-            @states[key] = ZoneCardState.new(key: key, **kwargs)
-          end
-
-          def public?
-            !!@public
-          end
-
-          def shared?
-            !!@shared
-          end
-
-          def ordered?
-            !!@ordered
-          end
+        def inspect
+          "<#{key} cards=#{cards}>"
         end
 
-        class Resource
-          attr_reader :key, :default
+        # TODO: copy over other stuff from legacy Zone base class
+      end
 
-          def initialize(key:, default:)
-            @key = key
-            @default = default
-          end
+      class Resource
+        attr_reader :owner, :definition
+
+        def initialize(owner:, definition:)
+          @owner = owner
+          @definition = definition
         end
 
-        class ZoneCardState
-          attr_reader :key, :default
-
-          def initialize(key:, default:)
-            @key = key
-            @default = default
-          end
+        def key
+          [owner.key, definition.key].join(".")
         end
       end
     end

--- a/lib/realms/zones.rb
+++ b/lib/realms/zones.rb
@@ -11,5 +11,314 @@ require "realms/zones/scrap_heap"
 
 module Realms
   module Zones
+    def self.layout
+      @layout ||= Builder.build do
+        # TODO: add default card pools to zones
+
+        shared do
+          zone(:trade_deck)
+          zone(:trade_row)
+          zone(:explorers)
+          zone(:scrap_heap)
+        end
+
+        players do
+          resource(:trade, default: 0)
+          resource(:combat, default: 0)
+          resource(:authority, default: 50)
+
+          # NOTE: push zone specific card state into card since the kind of state
+          #       seems like it would vary based on the kind of card.
+          #       Maybe there are defaults like age, played this turn, etc
+          zone(:hand)
+          zone(:in_play)
+          zone(:discard_pile)
+          zone(:draw_pile)
+
+          # helpers do
+          #   def discard(card)
+          #     hand.transfer!(card: card, to: discard_pile)
+          #   end
+
+          #   def play(card)
+          #     hand.transfer!(card: card, to: in_play)
+          #   end
+
+          #   def destroy(card)
+          #     in_play.transfer!(card: card, to: discard_pile)
+          #   end
+
+          #   def acquire(card, zone: discard_pile, pos: 0)
+          #     card.zone.transfer!(card: card, to: zone, pos: pos)
+          #   end
+
+          #   def scrap(card)
+          #     card.zone.transfer!(card: card, to: scrap_heap)
+          #   end
+
+          #   def discard_hand
+          #     until hand.empty?
+          #       discard(hand.first)
+          #     end
+          #   end
+
+          #   def draw(num = 1)
+          #     num.times do
+          #       if draw_pile.empty?
+          #         reshuffle
+          #         draw unless draw_pile.empty?
+          #       else
+          #         draw_pile.transfer!(to: hand)
+          #       end
+          #     end
+          #   end
+
+          #   def reshuffle
+          #     until discard_pile.empty? do
+          #       discard_pile.transfer!(to: draw_pile)
+          #     end
+          #     draw_pile.shuffle!(random: registry.rng)
+          #   end
+          # end
+        end
+      end
+    end
+
+    class Builder
+      def self.build(&config)
+        thing = new
+        thing.instance_exec(&config)
+        thing
+      end
+
+      attr_reader :perspectives
+
+      def initialize
+        @perspectives = {}
+      end
+
+      def players(&config)
+        perspectives[:players] = Config::Players.new.tap do |players_config|
+          players_config.instance_exec(&config) if block_given?
+        end
+      end
+
+      def shared(&config)
+        perspectives[:shared] = Config::Shared.new.tap do |shared_config|
+          shared_config.instance_exec(&config) if block_given?
+        end
+      end
+
+      def make(context)
+        evaluated_shared = perspectives[:shared].evaluate(context)
+        evaluated_players = perspectives[:players].evaluate(context)
+
+        Layouts::Layout.new(
+          :zones => (evaluated_shared.zones + evaluated_players.zones).index_by(&:key),
+          :resources => (evaluated_shared.resources + evaluated_players.resources).index_by(&:key)
+        )
+      end
+
+      module Layouts
+        class Layout
+          attr_reader :zones, :resources
+
+          def initialize(zones:, resources:)
+            @zones = zones
+            @resources = resources
+          end
+
+          # TODO: player layout perspectives?
+        end
+
+        class Zone
+          include Brainguy::Observer
+          include Brainguy::Observable
+
+          attr_reader :owner, :definition
+
+          def initialize(owner:, definition:, cards: [])
+            @owner = owner
+            @definition = definition
+            @cards = []
+          end
+
+          def key
+            [owner.key, definition.key].join(".")
+          end
+
+          def inspect
+            "<#{key} cards=#{cards}>"
+          end
+
+          # TODO: copy over other stuff from legacy Zone base class
+        end
+
+        class Resource
+          attr_reader :owner, :definition
+
+          def initialize(owner:, definition:)
+            @owner = owner
+            @definition = definition
+          end
+
+          def key
+            [owner.key, definition.key].join(".")
+          end
+        end
+      end
+
+      module Config
+        class Players
+          attr_reader :zones, :resources
+
+          def initialize
+            @zones = {}
+            @resources = {}
+          end
+
+          def resource(key, **kwargs)
+            @resources[key] = Resource.new(key: key, **kwargs)
+          end
+
+          def zone(key, **kwargs, &config)
+            @zones[key] = Zone.new(key: key, **kwargs)
+          end
+
+          def evaluate(context)
+            Evaluated.new(self, context)
+          end
+
+          class Evaluated
+            attr_reader :config, :context
+
+            def initialize(config, context)
+              @config = config
+              @context = context
+            end
+
+            def zones
+              @zones ||= players.each_with_object([]) do |player, zones|
+                config.zones.each do |_, zone_config|
+                  zones << Layouts::Zone.new(owner: player, definition: zone_config)
+                end
+              end
+            end
+
+            def resources
+              @resources ||= players.each_with_object([]) do |player, resources|
+                config.resources.each do |_, resource_config|
+                  resources << Layouts::Resource.new(owner: player, definition: resource_config)
+                end
+              end
+            end
+
+            private
+
+            # TODO: GameContext should define players
+            Player = Struct.new(:key)
+            def players
+              [Player.new("p1"), Player.new("p2")]
+            end
+          end
+        end
+
+        class Shared
+          attr_reader :zones, :resources
+
+          def initialize
+            @zones = {}
+            @resources = {}
+          end
+
+          def zone(key, **kwargs)
+            @zones[key] = Zone.new(key: key, **kwargs)
+          end
+
+          def resource(key, default:)
+            @resources[key] = Resource.new(key: key, default: default)
+          end
+
+          def evaluate(context)
+            Evaluated.new(self, context)
+          end
+
+          class Evaluated
+            attr_reader :config, :context
+
+            def initialize(config, context)
+              @config = config
+              @context = context
+            end
+
+            def zones
+              @zones ||= config.zones.each_with_object([]) do |(_, zone_config), zones|
+                zones << Layouts::Zone.new(owner: noone, definition: zone_config)
+              end
+            end
+
+            def resources
+              @resources ||= config.resources.each_with_object([]) do |(_, resource_config), resources|
+                resources << Layouts::Resources.new(owner: noone, definition: resource_config)
+              end
+            end
+
+            private
+
+            Noone = Struct.new(:key)
+
+            def noone
+              @noone ||= Noone.new("shared")
+            end
+          end
+        end
+
+        class Zone
+          attr_reader :key
+
+          def initialize(key:, public: false, shared: false, ordered: false)
+            @key = key
+            @public = public
+            @shared = shared
+            @ordered = ordered
+            @states = {}
+          end
+
+          def state(key, **kwargs)
+            @states[key] = ZoneCardState.new(key: key, **kwargs)
+          end
+
+          def public?
+            !!@public
+          end
+
+          def shared?
+            !!@shared
+          end
+
+          def ordered?
+            !!@ordered
+          end
+        end
+
+        class Resource
+          attr_reader :key, :default
+
+          def initialize(key:, default:)
+            @key = key
+            @default = default
+          end
+        end
+
+        class ZoneCardState
+          attr_reader :key, :default
+
+          def initialize(key:, default:)
+            @key = key
+            @default = default
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -3,8 +3,8 @@ require "spec_helper"
 RSpec.describe Realms::Game do
   let(:seed) { 42 }
   let(:game) { described_class.new(seed: seed) }
-  let(:p1) { game.active_player }
-  let(:p2) { game.passive_player }
+  let(:p1) { game.p1 }
+  let(:p2) { game.p2 }
 
   context "collecting events" do
     it "returns the game events that occurred as a result of a decision" do
@@ -41,8 +41,8 @@ RSpec.describe Realms::Game do
     it "plays" do
       game.start
 
-      expect(p1.authority).to eq(50)
-      expect(p2.authority).to eq(50)
+      expect(p1.authority.value).to eq(50)
+      expect(p2.authority.value).to eq(50)
 
       expect(p1.hand.length).to eq(3)
       expect(p2.hand.length).to eq(5)


### PR DESCRIPTION
Aiming for something like the following:

```ruby
    module Layout
      @layout ||= Builder.build do
        # TODO: add default card pools to zones

        shared do
          zone(:trade_deck, ordered: true)
          zone(:trade_row, public: true, ordered: true)
          zone(:explorers, public: true, ordered: true)
          zone(:scrap_heap, public: true, ordered: true)
        end

        players do
          resource(:trade, default: 0)
          resource(:combat, default: 0)
          resource(:authority, default: 50)

          # NOTE: push zone specific card state into card since the kind of state
          #       seems like it would vary based on the kind of card.
          #       Maybe there are defaults like age, played this turn, etc
          zone(:hand)
          zone(:in_play, public: true)
          zone(:discard_pile, public: true, ordered: true)
          zone(:draw_pile, ordered: true)
        end
      end
    end
```

The turn structure will be instantiated with the layout.

The layout defines the board state and the various perspectives of the board state.

The turn structure uses its context to access the right layout perspectives (e.g `active_player.hand`, `active_player.trade_row`)